### PR TITLE
CD-1960 fixed text overflow on permissions component for group name description

### DIFF
--- a/server/sonar-web/src/main/js/apps/permissions/shared/components/GroupHolder.tsx
+++ b/server/sonar-web/src/main/js/apps/permissions/shared/components/GroupHolder.tsx
@@ -67,7 +67,7 @@ export default class GroupHolder extends React.PureComponent<Props, State> {
 
     return (
       <tr>
-        <td className="nowrap text-middle">
+        <td className="display-flex-center text-middle">
           <div className="display-inline-block text-middle big-spacer-right">
             <GroupIcon />
           </div>

--- a/server/sonar-web/src/main/js/apps/permissions/shared/components/PermissionCell.tsx
+++ b/server/sonar-web/src/main/js/apps/permissions/shared/components/PermissionCell.tsx
@@ -35,7 +35,7 @@ export default class PermissionCell extends React.PureComponent<Props> {
     const { loading, onCheck, permission, permissionItem, selectedPermission } = this.props;
     if (isPermissionDefinitionGroup(permission)) {
       return (
-        <td className="text-middle">
+        <td className="text-middle nowrap">
           {permission.permissions.map(permission => (
             <div key={permission.key}>
               <Checkbox


### PR DESCRIPTION
Text overflow if group name or description have more number of characters than the available space. 

![text-overflow](https://user-images.githubusercontent.com/62242144/130009704-37ae8941-05c8-4d3c-9184-ec77a0f79e68.PNG)
![nowrap](https://user-images.githubusercontent.com/62242144/130009733-1f2b44af-2211-48da-9b18-ee9d051dd98d.PNG)

Screen after the changes: 
![permissionPage](https://user-images.githubusercontent.com/62242144/130009901-5d95f0bf-c5d2-49dc-973e-e3f8b879bfea.PNG)
