### PR TITLE
CD-1969 Calling codescan api to delete project

### DIFF
--- a/server/sonar-web/src/main/js/api/codescan.ts
+++ b/server/sonar-web/src/main/js/api/codescan.ts
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { getJSON } from 'sonar-ui-common/helpers/request';
+import { getJSON, post } from 'sonar-ui-common/helpers/request';
 import throwGlobalError from "../app/utils/throwGlobalError";
 
 export function getNotificationsForOrganization(key: string) {
@@ -25,4 +25,12 @@ export function getNotificationsForOrganization(key: string) {
       r => r.organization,
       throwGlobalError
   );
+}
+
+export function deleteIntegration(data: {
+  organizationId: string;
+  projectKey: string;
+  projectDelete?: boolean;
+}): Promise<void> {
+  return post('/_codescan/integrations/destroy', data);
 }

--- a/server/sonar-web/src/main/js/api/codescan.ts
+++ b/server/sonar-web/src/main/js/api/codescan.ts
@@ -22,8 +22,8 @@ import throwGlobalError from "../app/utils/throwGlobalError";
 
 export function getNotificationsForOrganization(key: string) {
   return getJSON('/_codescan/notifications', { organizationId: key }).then(
-      r => r.organization,
-      throwGlobalError
+    r => r.organization,
+    throwGlobalError
   );
 }
 

--- a/server/sonar-web/src/main/js/apps/projectDeletion/Form.tsx
+++ b/server/sonar-web/src/main/js/apps/projectDeletion/Form.tsx
@@ -28,7 +28,7 @@ import { Router, withRouter } from '../../components/hoc/withRouter';
 import { ComponentQualifier, isPortfolioLike } from '../../types/component';
 
 interface Props {
-  component: Pick<T.Component, 'key' | 'name' | 'qualifier'| 'organization'>;
+  component: Pick<T.Component, 'key' | 'name' | 'qualifier' | 'organization'>;
   router: Pick<Router, 'replace'>;
 }
 

--- a/server/sonar-web/src/main/js/apps/projectDeletion/Form.tsx
+++ b/server/sonar-web/src/main/js/apps/projectDeletion/Form.tsx
@@ -21,24 +21,26 @@ import * as React from 'react';
 import { Button } from 'sonar-ui-common/components/controls/buttons';
 import ConfirmButton from 'sonar-ui-common/components/controls/ConfirmButton';
 import { translate, translateWithParameters } from 'sonar-ui-common/helpers/l10n';
-import { deletePortfolio, deleteProject } from '../../api/components';
+import { deleteIntegration } from '../../api/codescan';
+import { deletePortfolio } from '../../api/components';
 import addGlobalSuccessMessage from '../../app/utils/addGlobalSuccessMessage';
 import { Router, withRouter } from '../../components/hoc/withRouter';
 import { ComponentQualifier, isPortfolioLike } from '../../types/component';
 
 interface Props {
-  component: Pick<T.Component, 'key' | 'name' | 'qualifier'>;
+  component: Pick<T.Component, 'key' | 'name' | 'qualifier'| 'organization'>;
   router: Pick<Router, 'replace'>;
 }
 
 export class Form extends React.PureComponent<Props> {
   handleDelete = async () => {
     const { component } = this.props;
-    const deleteMethod =
-      component.qualifier === ComponentQualifier.Project ? deleteProject : deletePortfolio;
+    component.qualifier === ComponentQualifier.Project ? await deleteIntegration({
+      organizationId: component.organization,
+      projectKey: component.key,
+      projectDelete: true
+    }) : await deletePortfolio(component.key)
     const redirectTo = isPortfolioLike(component.qualifier) ? '/portfolios' : '/';
-
-    await deleteMethod(component.key);
 
     addGlobalSuccessMessage(
       translateWithParameters('project_deletion.resource_deleted', component.name)

--- a/server/sonar-web/src/main/js/apps/projectDeletion/Form.tsx
+++ b/server/sonar-web/src/main/js/apps/projectDeletion/Form.tsx
@@ -39,7 +39,7 @@ export class Form extends React.PureComponent<Props> {
       organizationId: component.organization,
       projectKey: component.key,
       projectDelete: true
-    }) : await deletePortfolio(component.key)
+    }) : await deletePortfolio(component.key);
     const redirectTo = isPortfolioLike(component.qualifier) ? '/portfolios' : '/';
 
     addGlobalSuccessMessage(


### PR DESCRIPTION
In-order to deleted the webhooks on respective VC systems- Calling Codescan API instead of SonarQube API to delete the project, analysis and webhooks. 