### PR TITLE
CD-2181 Fix log4j2 vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ subprojects {
         exclude 'commons-logging:commons-logging'
       }
       // Be aware that Log4j is used by Elasticsearch client
-      dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
+      dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
         entry 'log4j-api'
         entry 'log4j-to-slf4j'
         entry 'log4j-core'

--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ subprojects {
         exclude 'commons-logging:commons-logging'
       }
       // Be aware that Log4j is used by Elasticsearch client
-      dependencySet(group: 'org.apache.logging.log4j', version: '2.8.2') {
+      dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
         entry 'log4j-api'
         entry 'log4j-to-slf4j'
         entry 'log4j-core'


### PR DESCRIPTION
Upgrade Log4j2 version to fix the vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228

