### PR TITLE
CD-2181 update log4j version to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ subprojects {
         exclude 'commons-logging:commons-logging'
       }
       // Be aware that Log4j is used by Elasticsearch client
-      dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
+      dependencySet(group: 'org.apache.logging.log4j', version: '2.17.0') {
         entry 'log4j-api'
         entry 'log4j-to-slf4j'
         entry 'log4j-core'


### PR DESCRIPTION
Includes fix to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105