### PR TITLE
CD-2560 Update SonarJs from 6.5.0.13383 to 8.1.0.15788

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
   id 'com.google.protobuf' version '0.8.12' apply false
   id 'com.jfrog.artifactory' version '4.15.1'
-  id 'com.github.node-gradle.node' version '1.5.3' apply false
+  id 'com.github.node-gradle.node' version '2.2.4' apply false
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'net.rdrei.android.buildtimetracker' version '0.11.0'
   id 'org.owasp.dependencycheck' version '6.0.1'
@@ -214,7 +214,7 @@ subprojects {
       dependency 'org.sonarsource.html:sonar-html-plugin:3.2.0.2082' // bundled_plugin:web:sonar-html
       dependency 'org.sonarsource.jacoco:sonar-jacoco-plugin:1.1.0.898' // bundled_plugin:jacoco:sonar-jacoco
       dependency 'org.sonarsource.java:sonar-java-plugin:7.6.0.28201' // bundled_plugin:java:sonar-java
-      dependency 'org.sonarsource.javascript:sonar-javascript-plugin:6.5.0.13383' // bundled_plugin:javascript:SonarJS
+      dependency 'org.sonarsource.javascript:sonar-javascript-plugin:8.1.0.15788' // bundled_plugin:javascript:SonarJS
       dependency 'org.sonarsource.php:sonar-php-plugin:3.9.0.6331' // bundled_plugin:php:sonar-php
       dependency 'org.sonarsource.python:sonar-python-plugin:3.1.0.7619' // bundled_plugin:python:sonar-python
       dependency 'org.sonarsource.slang:sonar-go-plugin:1.6.0.719' // bundled_plugin:go:slang-enterprise
@@ -483,8 +483,8 @@ subprojects {
     apply plugin: 'com.github.node-gradle.node'
 
     node {
-      version = '10.15.3'
-      yarnVersion = '1.22.0'
+      version = '14.17.5'
+      yarnVersion = '1.22.11'
       download = true
     }
 

--- a/codescan-application/build.gradle
+++ b/codescan-application/build.gradle
@@ -180,7 +180,7 @@ zip.doFirst {
 // Check the size of the archive
 zip.doLast {
   def minLength = 205000000
-  def maxLength = 240000000
+  def maxLength = 250000000
 
   def length = archiveFile.get().asFile.length()
   if (length < minLength)

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -179,7 +179,7 @@ zip.doFirst {
 // Check the size of the archive
 zip.doLast {
   def minLength = 220000000
-  def maxLength = 240000000
+  def maxLength = 250000000
 
   def length = archiveFile.get().asFile.length()
   if (length < minLength)


### PR DESCRIPTION
SonarJs has been updated to newer version which has the fix https://github.com/SonarSource/SonarJS/pull/2505
which is causing project analysis to fail due to low value of timeout.

After this fix, Codescan jars which are compatible with SonarJs 8.1 needs to be used. i.e The jars shared for self-hosted customers are the ones to be used for this. (ie with fix for renamed javascript rules)

