### PR TITLE
CD-3701 - Redirecting to BLANK page when a rule opened under Rules Tab

### DIFF
--- a/server/sonar-web/src/main/js/app/components/nav/component/projectInformation/meta/MetaQualityProfiles.tsx
+++ b/server/sonar-web/src/main/js/app/components/nav/component/projectInformation/meta/MetaQualityProfiles.tsx
@@ -74,7 +74,7 @@ export class MetaQualityProfiles extends React.PureComponent<Props, State> {
   loadDeprecatedRulesForProfile(profileKey: string) {
     const data = {
       activation: 'true',
-      organization: string,
+      organization: this.props.organization,
       ps: 1,
       qprofile: profileKey,
       statuses: 'DEPRECATED',

--- a/server/sonar-web/src/main/js/apps/coding-rules/components/RuleDetailsIssues.tsx
+++ b/server/sonar-web/src/main/js/apps/coding-rules/components/RuleDetailsIssues.tsx
@@ -135,9 +135,9 @@ export class RuleDetailsIssues extends React.PureComponent<Props, State> {
   renderProject = (project: Project) => {
     const {
       ruleDetails: { key },
+      organization
     } = this.props;
-
-    const path = getIssuesUrl({ resolved: 'false', rules: key, projects: project.key }, organization);
+    const path = getOrgIssuesUrl({ resolved: 'false', rules: key, projects: project.key }, organization);
     return (
       <tr key={project.key}>
         <td className="coding-rules-detail-list-name">{project.name}</td>

--- a/server/sonar-web/src/main/js/apps/coding-rules/components/RuleDetailsProfiles.tsx
+++ b/server/sonar-web/src/main/js/apps/coding-rules/components/RuleDetailsProfiles.tsx
@@ -70,7 +70,6 @@ export default class RuleDetailsProfiles extends React.PureComponent<Props> {
     if (!profile.parentName) {
       return null;
     }
-    console.log("organization ->"+organization);
     const profilePath = getQualityProfileUrl(profile.parentName, profile.language, organization);
     return (
       <div className="coding-rules-detail-quality-profile-inheritance">


### PR DESCRIPTION
CD-3701 - Redirecting to BLANK page when a rule opened under Rules Tab
CD-3726 - Blank page is displaying if User selects Project information on Project Overview page