### PR TITLE
CD-4134 Limit Access to User Search API to only System Admin or Org A…

### DIFF
--- a/server/sonar-server-common/src/main/java/org/sonar/server/user/index/UserIndex.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/user/index/UserIndex.java
@@ -43,6 +43,7 @@ import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.sonar.server.es.newindex.DefaultIndexSettingsElement.SORTABLE_ANALYZER;
 import static org.sonar.server.es.newindex.DefaultIndexSettingsElement.USER_SEARCH_GRAMS_ANALYZER;
 import static org.sonar.server.user.index.UserIndexDefinition.FIELD_ACTIVE;
@@ -91,25 +92,30 @@ public class UserIndex {
 
   public SearchResult<UserDoc> search(UserQuery userQuery, SearchOptions options) {
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-      .size(options.getLimit())
-      .from(options.getOffset())
-      .sort(FIELD_NAME, SortOrder.ASC);
+            .size(options.getLimit())
+            .from(options.getOffset())
+            .sort(FIELD_NAME, SortOrder.ASC);
 
     BoolQueryBuilder filter = boolQuery().must(termQuery(FIELD_ACTIVE, userQuery.isActive()));
+    // UserQuery for Search Members API uses a single organization.
     userQuery.getOrganizationUuid()
             .ifPresent(o -> filter.must(termQuery(FIELD_ORGANIZATION_UUIDS, o)));
     userQuery.getExcludedOrganizationUuid()
             .ifPresent(o -> filter.mustNot(termQuery(FIELD_ORGANIZATION_UUIDS, o)));
+    // UserQuery for SearchAction uses a list of multiple organizations.
+    if (!userQuery.getOrganizationUuids().isEmpty()) {
+      filter.must(termsQuery(FIELD_ORGANIZATION_UUIDS, userQuery.getOrganizationUuids()));
+    }
 
     QueryBuilder esQuery = matchAllQuery();
     Optional<String> textQuery = userQuery.getTextQuery();
     if (textQuery.isPresent()) {
       esQuery = QueryBuilders.multiMatchQuery(textQuery.get(),
-        FIELD_LOGIN,
-        USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_LOGIN),
-        FIELD_NAME,
-        USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_NAME),
-        FIELD_EMAIL,
+                      FIELD_LOGIN,
+                      USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_LOGIN),
+                      FIELD_NAME,
+                      USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_NAME),
+                      FIELD_EMAIL,
         USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_EMAIL))
         .operator(Operator.AND);
     }

--- a/server/sonar-server-common/src/main/java/org/sonar/server/user/index/UserIndex.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/user/index/UserIndex.java
@@ -92,9 +92,9 @@ public class UserIndex {
 
   public SearchResult<UserDoc> search(UserQuery userQuery, SearchOptions options) {
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .size(options.getLimit())
-            .from(options.getOffset())
-            .sort(FIELD_NAME, SortOrder.ASC);
+      .size(options.getLimit())
+      .from(options.getOffset())
+      .sort(FIELD_NAME, SortOrder.ASC);
 
     BoolQueryBuilder filter = boolQuery().must(termQuery(FIELD_ACTIVE, userQuery.isActive()));
     // UserQuery for Search Members API uses a single organization.
@@ -111,12 +111,12 @@ public class UserIndex {
     Optional<String> textQuery = userQuery.getTextQuery();
     if (textQuery.isPresent()) {
       esQuery = QueryBuilders.multiMatchQuery(textQuery.get(),
-                      FIELD_LOGIN,
-                      USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_LOGIN),
-                      FIELD_NAME,
-                      USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_NAME),
-                      FIELD_EMAIL,
-        USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_EMAIL))
+          FIELD_LOGIN,
+          USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_LOGIN),
+          FIELD_NAME,
+          USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_NAME),
+          FIELD_EMAIL,
+          USER_SEARCH_GRAMS_ANALYZER.subField(FIELD_EMAIL))
         .operator(Operator.AND);
     }
 

--- a/server/sonar-server-common/src/main/java/org/sonar/server/user/index/UserQuery.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/user/index/UserQuery.java
@@ -19,6 +19,11 @@
  */
 package org.sonar.server.user.index;
 
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -30,12 +35,14 @@ public class UserQuery {
   private final String textQuery;
   private final String organizationUuid;
   private final String excludedOrganizationUuid;
+  private List<String> organizationUuids;
   private final boolean active;
 
   private UserQuery(Builder builder) {
     this.textQuery = builder.textQuery;
     this.organizationUuid = builder.organizationUuid;
     this.excludedOrganizationUuid = builder.excludedOrganizationUuid;
+    this.organizationUuids = ImmutableList.copyOf(builder.organizationUuids);
     this.active = builder.active;
   }
 
@@ -51,6 +58,10 @@ public class UserQuery {
     return Optional.ofNullable(excludedOrganizationUuid);
   }
 
+  public List<String> getOrganizationUuids() {
+    return organizationUuids;
+  }
+
   public boolean isActive() {
     return active;
   }
@@ -63,6 +74,7 @@ public class UserQuery {
     private String textQuery;
     private String organizationUuid;
     private String excludedOrganizationUuid;
+    private List<String> organizationUuids = new ArrayList<>();
     private boolean active = true;
 
     private Builder() {
@@ -91,6 +103,14 @@ public class UserQuery {
      */
     public Builder setExcludedOrganizationUuid(@Nullable String excludedOrganizationUuid) {
       this.excludedOrganizationUuid = excludedOrganizationUuid;
+      return this;
+    }
+
+    /**
+     * Include only users that are members of at least one of the OrganizationUuids
+     */
+    public Builder addOrganizationUuids(List<String> organizationUuids) {
+      this.organizationUuids.addAll(organizationUuids);
       return this;
     }
 

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/user/ws/SearchAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/user/ws/SearchAction.java
@@ -83,22 +83,12 @@ public class SearchAction implements UsersWsAction {
   public void define(WebService.NewController controller) {
     WebService.NewAction action = controller.createAction("search")
       .setDescription("Get a list of users. By default, only active users are returned.<br/>" +
-        "The following fields are only returned when user has Administer System permission or for logged-in in user "
-        + "or for Organization Admin :" +
-        "<ul>" +
-        "   <li>'email'</li>" +
-        "   <li>'externalIdentity'</li>" +
-        "   <li>'externalProvider'</li>" +
-        "   <li>'groups'</li>" +
-        "   <li>'lastConnectionDate'</li>" +
-        "   <li>'tokensCount'</li>" +
-        "</ul>" +
-        "Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user authenticates many " +
-        "times in less than one hour.")
+        "Requires 'Administer System' permission at an Organization Level or at Global Level." +
+        " For Organization Admins, list of users part of the organization(s) are returned")
       .setSince("3.6")
       .setChangelog(
         new Change("9.9", "Organization Admin can access Email and Last Connection Info of all members of the "
-          + "organization"),
+          + "organization. API is accessible only for System Administrators or Organization Administrators"),
         new Change("9.7", "New parameter 'deactivated' to optionally search for deactivated users"),
         new Change("7.7", "New field 'lastConnectionDate' is added to response"),
         new Change("7.4", "External identity is only returned to system administrators"),
@@ -199,8 +189,7 @@ public class SearchAction implements UsersWsAction {
         userBuilder.setScmAccounts(ScmAccounts.newBuilder().addAllScmAccounts(user.getScmAccountsAsList()));
       }
     }
-    if (userSession.isSystemAdministrator() || Objects.equals(userSession.getUuid(), user.getUuid())
-      || showEmailAndLastConnectionInfo) {
+    if (userSession.isSystemAdministrator() || showEmailAndLastConnectionInfo) {
       ofNullable(user.getEmail()).ifPresent(userBuilder::setEmail);
       if (!groups.isEmpty()) {
         userBuilder.setGroups(Groups.newBuilder().addAllGroups(groups));
@@ -208,7 +197,7 @@ public class SearchAction implements UsersWsAction {
       ofNullable(user.getExternalLogin()).ifPresent(userBuilder::setExternalIdentity);
       ofNullable(tokensCount).ifPresent(userBuilder::setTokensCount);
       ofNullable(user.getLastConnectionDate()).ifPresent(
-              date -> userBuilder.setLastConnectionDate(formatDateTime(date)));
+        date -> userBuilder.setLastConnectionDate(formatDateTime(date)));
     }
     return userBuilder.build();
   }

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/user/ws/SearchAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/user/ws/SearchAction.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.api.server.ws.Change;
@@ -33,6 +34,7 @@ import org.sonar.api.server.ws.WebService;
 import org.sonar.api.utils.Paging;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
+import org.sonar.db.permission.OrganizationPermission;
 import org.sonar.db.user.UserDto;
 import org.sonar.server.es.SearchOptions;
 import org.sonar.server.es.SearchResult;
@@ -54,6 +56,7 @@ import static org.sonar.api.server.ws.WebService.Param.TEXT_QUERY;
 import static org.sonar.api.utils.DateUtils.formatDateTime;
 import static org.sonar.api.utils.Paging.forPageIndex;
 import static org.sonar.core.util.stream.MoreCollectors.toList;
+import static org.sonar.server.user.AbstractUserSession.insufficientPrivilegesException;
 import static org.sonar.server.ws.WsUtils.writeProtobuf;
 import static org.sonarqube.ws.Users.SearchWsResponse.Groups;
 import static org.sonarqube.ws.Users.SearchWsResponse.ScmAccounts;
@@ -80,24 +83,27 @@ public class SearchAction implements UsersWsAction {
   public void define(WebService.NewController controller) {
     WebService.NewAction action = controller.createAction("search")
       .setDescription("Get a list of users. By default, only active users are returned.<br/>" +
-        "The following fields are only returned when user has Administer System permission or for logged-in in user :" +
-        "<ul>" +
-        "   <li>'email'</li>" +
-        "   <li>'externalIdentity'</li>" +
-        "   <li>'externalProvider'</li>" +
-        "   <li>'groups'</li>" +
-        "   <li>'lastConnectionDate'</li>" +
-        "   <li>'tokensCount'</li>" +
-        "</ul>" +
-        "Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.")
+              "The following fields are only returned when user has Administer System permission or for logged-in in user "
+              + "or for Organization Admin :" +
+              "<ul>" +
+              "   <li>'email'</li>" +
+              "   <li>'externalIdentity'</li>" +
+              "   <li>'externalProvider'</li>" +
+              "   <li>'groups'</li>" +
+              "   <li>'lastConnectionDate'</li>" +
+              "   <li>'tokensCount'</li>" +
+              "</ul>" +
+              "Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.")
       .setSince("3.6")
       .setChangelog(
-        new Change("9.7", "New parameter 'deactivated' to optionally search for deactivated users"),
-        new Change("7.7", "New field 'lastConnectionDate' is added to response"),
-        new Change("7.4", "External identity is only returned to system administrators"),
-        new Change("6.4", "Paging response fields moved to a Paging object"),
-        new Change("6.4", "Avatar has been added to the response"),
-        new Change("6.4", "Email is only returned when user has Administer System permission"))
+              new Change("9.9", "Organization Admin can access Email and Last Connection Info of all members of the "
+                      + "organization"),
+              new Change("9.7", "New parameter 'deactivated' to optionally search for deactivated users"),
+              new Change("7.7", "New field 'lastConnectionDate' is added to response"),
+              new Change("7.4", "External identity is only returned to system administrators"),
+              new Change("6.4", "Paging response fields moved to a Paging object"),
+              new Change("6.4", "Avatar has been added to the response"),
+              new Change("6.4", "Email is only returned when user has Administer System permission"))
       .setHandler(this)
       .setResponseExample(getClass().getResource("search-example.json"));
 
@@ -132,30 +138,55 @@ public class SearchAction implements UsersWsAction {
   }
 
   private Users.SearchWsResponse doHandle(SearchRequest request) {
+    boolean isSystemAdmin = userSession.checkLoggedIn().isSystemAdministrator();
+    boolean showEmailAndLastConnectionInfo = false;
+    var userQuery = UserQuery.builder();
     SearchOptions options = new SearchOptions().setPage(request.getPage(), request.getPageSize());
-    SearchResult<UserDoc> result = userIndex.search(UserQuery.builder().setActive(!request.isDeactivated()).setTextQuery(request.getQuery()).build(), options);
+    if (!isSystemAdmin) {
+      List<String> userOrganizations =
+              userIndex.search(UserQuery.builder().setActive(true).setTextQuery(userSession.getLogin()).build(),
+                      options).getDocs().get(0).organizationUuids();
+      var orgsWithUserAsAdmin =
+              userOrganizations.stream().filter(o -> userSession.hasPermission(OrganizationPermission.ADMINISTER, o))
+                      .collect(
+                              Collectors.toList());
+      if (!orgsWithUserAsAdmin.isEmpty()) {
+        userQuery.addOrganizationUuids(orgsWithUserAsAdmin);
+        showEmailAndLastConnectionInfo = true;
+      } else {
+        throw insufficientPrivilegesException();
+      }
+    }
+    SearchResult<UserDoc> result = userIndex.search(
+            userQuery.setActive(!request.isDeactivated()).setTextQuery(request.getQuery()).build(), options);
     try (DbSession dbSession = dbClient.openSession(false)) {
       List<String> logins = result.getDocs().stream().map(UserDoc::login).collect(toList());
       Multimap<String, String> groupsByLogin = dbClient.groupMembershipDao().selectGroupsByLogins(dbSession, logins);
       List<UserDto> users = dbClient.userDao().selectByOrderedLogins(dbSession, logins);
       Map<String, Integer> tokenCountsByLogin = dbClient.userTokenDao().countTokensByUsers(dbSession, users);
-      Paging paging = forPageIndex(request.getPage()).withPageSize(request.getPageSize()).andTotal((int) result.getTotal());
-      return buildResponse(users, groupsByLogin, tokenCountsByLogin, paging);
+      Paging paging = forPageIndex(request.getPage()).withPageSize(request.getPageSize())
+              .andTotal((int) result.getTotal());
+      return buildResponse(users, groupsByLogin, tokenCountsByLogin, paging, showEmailAndLastConnectionInfo);
     }
   }
 
-  private SearchWsResponse buildResponse(List<UserDto> users, Multimap<String, String> groupsByLogin, Map<String, Integer> tokenCountsByLogin, Paging paging) {
+  private SearchWsResponse buildResponse(List<UserDto> users, Multimap<String, String> groupsByLogin,
+          Map<String, Integer> tokenCountsByLogin, Paging paging,
+          boolean showEmailAndLastConnectionInfo) {
     SearchWsResponse.Builder responseBuilder = newBuilder();
-    users.forEach(user -> responseBuilder.addUsers(towsUser(user, firstNonNull(tokenCountsByLogin.get(user.getUuid()), 0), groupsByLogin.get(user.getLogin()))));
+    users.forEach(user -> responseBuilder.addUsers(
+            towsUser(user, firstNonNull(tokenCountsByLogin.get(user.getUuid()), 0),
+                    groupsByLogin.get(user.getLogin()), showEmailAndLastConnectionInfo)));
     responseBuilder.getPagingBuilder()
-      .setPageIndex(paging.pageIndex())
-      .setPageSize(paging.pageSize())
-      .setTotal(paging.total())
-      .build();
+            .setPageIndex(paging.pageIndex())
+            .setPageSize(paging.pageSize())
+            .setTotal(paging.total())
+            .build();
     return responseBuilder.build();
   }
 
-  private User towsUser(UserDto user, @Nullable Integer tokensCount, Collection<String> groups) {
+  private User towsUser(UserDto user, @Nullable Integer tokensCount, Collection<String> groups,
+          boolean showEmailAndLastConnectionInfo) {
     User.Builder userBuilder = User.newBuilder().setLogin(user.getLogin());
     ofNullable(user.getName()).ifPresent(userBuilder::setName);
     if (userSession.isLoggedIn()) {
@@ -167,14 +198,16 @@ public class SearchAction implements UsersWsAction {
         userBuilder.setScmAccounts(ScmAccounts.newBuilder().addAllScmAccounts(user.getScmAccountsAsList()));
       }
     }
-    if (userSession.isSystemAdministrator() || Objects.equals(userSession.getUuid(), user.getUuid())) {
+    if (userSession.isSystemAdministrator() || Objects.equals(userSession.getUuid(), user.getUuid())
+            || showEmailAndLastConnectionInfo) {
       ofNullable(user.getEmail()).ifPresent(userBuilder::setEmail);
       if (!groups.isEmpty()) {
         userBuilder.setGroups(Groups.newBuilder().addAllGroups(groups));
       }
       ofNullable(user.getExternalLogin()).ifPresent(userBuilder::setExternalIdentity);
       ofNullable(tokensCount).ifPresent(userBuilder::setTokensCount);
-      ofNullable(user.getLastConnectionDate()).ifPresent(date -> userBuilder.setLastConnectionDate(formatDateTime(date)));
+      ofNullable(user.getLastConnectionDate()).ifPresent(
+              date -> userBuilder.setLastConnectionDate(formatDateTime(date)));
     }
     return userBuilder.build();
   }


### PR DESCRIPTION
**Security issue:**
 A user is able to see list of users from multiple organizations simply by leaving the criteria blank and changing the pagination parameter all the way up to 150 pages.

https://app.codescan.io/api/users/search?p=5

**Requirement:**
System Admin should be able to view all the users present across organizations.
For organization admins, users part of their orgs will be listed.
Enable the option to view emails and last connection date for organization admins and system admins.
For Other users, forbidden error is displayed.