### PR TITLE
[CD-4953] Support for showing multiple codescan notifications and added logic to show only errors when both errors and warnings are present

### DIFF
--- a/server/sonar-web/src/main/js/api/codescan.ts
+++ b/server/sonar-web/src/main/js/api/codescan.ts
@@ -19,10 +19,11 @@
  */
 import { deleteRequest, getJSON, post, postJSON } from '../helpers/request';
 import { throwGlobalError } from '../helpers/error';
-import { Visibility } from "../types/types";
+import { Visibility, Notification } from "../types/types";
 
-export function getRawNotificationsForOrganization(key: string){
-  return getJSON('/_codescan/notifications', { organizationId: key });
+export function getRawNotificationsForOrganization(key: string) : Promise<Notification> {
+  return getJSON('/_codescan/notifications', { organizationId: key })
+      .catch(throwGlobalError);
 }
 
 export function deleteProject(uuid: string, deleteProject?: boolean): Promise<void> {

--- a/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigation.tsx
+++ b/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigation.tsx
@@ -45,19 +45,19 @@ export class OrganizationNavigation extends React.PureComponent<Props, State> {
 
  componentDidMount() {
     this.mounted = true;
-    this.fetchNotificiations();
+    this.fetchNotifications();
   }
 
   componentDidUpdate() {
-    this.fetchNotificiations();  
+    this.fetchNotifications();
   }
 
-  async fetchNotificiations() {
+  async fetchNotifications() {
     const { organization } = { ...this.props }
     await getRawNotificationsForOrganization(organization.kee).then((data:any) => {
-      const notfication = data?.organization?.notifications?.[0];
-      if(notfication?.type === "error") {
-        this.setState({ error: notfication.message });
+      const notification = data?.[0];
+      if(notification?.type === "ERROR") {
+        this.setState({ error: notification.message });
       } else {
         this.setState({ error: '' });  
       }

--- a/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigation.tsx
+++ b/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigation.tsx
@@ -23,9 +23,9 @@ import OrganizationNavigationMenu from './OrganizationNavigationMenu';
 import OrganizationNavigationMeta from './OrganizationNavigationMeta';
 import { rawSizes } from '../../../app/theme';
 import ContextNavBar from "../../../components/ui/ContextNavBar";
-import { Organization } from "../../../types/types";
+import { Organization, Notification } from "../../../types/types";
 import { getRawNotificationsForOrganization } from '../../../../js/api/codescan';
-import { throwGlobalError } from '../../../../js/helpers/error';
+import { sanitizeUserInput } from '../../../helpers/sanitize';
 
 interface Props {
   location: { pathname: string };
@@ -33,83 +33,62 @@ interface Props {
   userOrganizations: Organization[];
 }
 
-interface State{
-  error: string,
-}
+export function OrganizationNavigation({ location, organization, userOrganizations }: Props) {
+  const [notifications, setNotifications] = React.useState<Notification[]>([]);
+  const { contextNavHeightRaw, contextNavHeightWithError } = rawSizes;
+  const [height, setHeight] = React.useState(contextNavHeightRaw);
+  const orgAlertHeight = 30; // refer .org-alert-warning height in NavBarTabs
 
-export class OrganizationNavigation extends React.PureComponent<Props, State> {
-  mounted = false;
-  state: State = {
-    error: ''
-  };
+  React.useEffect(() => {
+    const fetchNotifications = async () => {
+        const notifications = await getRawNotificationsForOrganization(organization.kee);
+        if(notifications.length > 0) {
+          const errorNotifications = notifications.filter(notification => notification.type == 'ERROR');
+          if(errorNotifications.length > 0) {
+            setNotifications(errorNotifications);
+            setHeight(contextNavHeightWithError + orgAlertHeight * (errorNotifications.length - 1));
+          } else {
+            setNotifications(notifications);
+            setHeight(contextNavHeightWithError + orgAlertHeight * (notifications.length - 1));
+          }
+        } else {
+          setNotifications([]);
+          setHeight(contextNavHeightRaw);
+        }
+    };
+    fetchNotifications();
+  },[organization, userOrganizations]);
 
- componentDidMount() {
-    this.mounted = true;
-    this.fetchNotifications();
-  }
-
-  componentDidUpdate() {
-    this.fetchNotifications();
-  }
-
-  async fetchNotifications() {
-    const { organization } = { ...this.props }
-    await getRawNotificationsForOrganization(organization.kee).then((data:any) => {
-      const notification = data?.[0];
-      if(notification?.type === "ERROR") {
-        this.setState({ error: notification.message });
-      } else {
-        this.setState({ error: '' });  
-      }
-    }).catch(throwGlobalError)
-  }
-
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  render(){
-    const { contextNavHeightRaw, contextNavHeightWithError } = rawSizes;
-    const {location,organization,userOrganizations} = {...this.props}  
-    const {error} = {...this.state};
-    
-    const height = (error?.length>0) ? contextNavHeightWithError : contextNavHeightRaw;
-    return (
-      <>
-      <ContextNavBar height={height} id="context-navigation">
-        <div className="navbar-context-justified">
-          <OrganizationNavigationHeader
-              organization={organization}
-              organizations={userOrganizations}
-          />
-          <OrganizationNavigationMeta
-              organization={organization}
-          />
-        </div>
-        <OrganizationNavigationMenu
-            location={location}
-            organization={organization}
-        />
-        {
-        error?.length>0 ? (
-        <div className='org-alert'>
-          <div className='org-alert-inner'>
-            <div className='icon'>
-              x
-            </div>
-            <div className='msg'>
-              {error}
-            </div>
+  return (
+        <>
+        <ContextNavBar height={height} id="context-navigation">
+          <div className="navbar-context-justified">
+            <OrganizationNavigationHeader
+                organization={organization}
+                organizations={userOrganizations}
+            />
+            <OrganizationNavigationMeta
+                organization={organization}
+            />
           </div>
-        </div>
-        ) : (<></>)
-      }
-      </ContextNavBar>
-    </>
-  );
-  }
-
+          <OrganizationNavigationMenu
+              location={location}
+              organization={organization}
+          />
+          { notifications.length>0 ? notifications.map((notification, key) => (
+            <div className={notification.type === 'ERROR' ? 'org-alert-error' : 'org-alert-warning'} key = {key}>
+              <div className='org-alert-inner'>
+                <div className='icon'>
+                  {notification.type === 'ERROR' ? 'x' : '!'}
+                </div>
+                <div className='msg' dangerouslySetInnerHTML={{ __html: sanitizeUserInput(notification.message) }} />
+              </div>
+            </div>
+          )) : (<></>)
+          }
+        </ContextNavBar>
+      </>
+    );
 }
 
 export default OrganizationNavigation;

--- a/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigation.tsx
+++ b/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigation.tsx
@@ -42,9 +42,9 @@ export function OrganizationNavigation({ location, organization, userOrganizatio
   React.useEffect(() => {
     const fetchNotifications = async () => {
         const notifications = await getRawNotificationsForOrganization(organization.kee);
-        if(notifications.length > 0) {
+        if (notifications.length > 0) {
           const errorNotifications = notifications.filter(notification => notification.type == 'ERROR');
-          if(errorNotifications.length > 0) {
+          if (errorNotifications.length > 0) {
             setNotifications(errorNotifications);
             setHeight(contextNavHeightWithError + orgAlertHeight * (errorNotifications.length - 1));
           } else {
@@ -75,16 +75,16 @@ export function OrganizationNavigation({ location, organization, userOrganizatio
               location={location}
               organization={organization}
           />
-          { notifications.length>0 ? notifications.map((notification, key) => (
-            <div className={notification.type === 'ERROR' ? 'org-alert-error' : 'org-alert-warning'} key = {key}>
-              <div className='org-alert-inner'>
-                <div className='icon'>
-                  {notification.type === 'ERROR' ? 'x' : '!'}
+          { notifications.map((notification, key) => (
+              <div className={"org-alert-" + notification.type.toLowerCase()} key={key}>
+                <div className='org-alert-inner'>
+                  <div className='icon'>
+                    {notification.type === 'ERROR' ? 'x' : '!'}
+                  </div>
+                  <div className='msg' dangerouslySetInnerHTML={{ __html: sanitizeUserInput(notification.message) }} />
                 </div>
-                <div className='msg' dangerouslySetInnerHTML={{ __html: sanitizeUserInput(notification.message) }} />
               </div>
-            </div>
-          )) : (<></>)
+            ))
           }
         </ContextNavBar>
       </>

--- a/server/sonar-web/src/main/js/components/ui/NavBarTabs.css
+++ b/server/sonar-web/src/main/js/components/ui/NavBarTabs.css
@@ -49,7 +49,7 @@
 .navbar-tabs > li > .button-link:focus {
   border-bottom-color: var(--blue);
 }
-.org-alert{
+.org-alert-error{
   border: 1px solid #f4b1b0;
   background-color: #f2dede;
   color: #862422;
@@ -60,7 +60,7 @@
     margin-left: auto;
     margin-right: auto;
 }
-.org-alert .icon{
+.org-alert-error .icon{
   float: left;
   color: #f2dede;
   border-radius: 54px;
@@ -71,7 +71,28 @@
   padding-left: 8px;
   font-size: 12px;
 }
-.org-alert .msg{
+.org-alert-error .msg{
+  float:left;
+  padding: 7px;
+}
+.org-alert-warning{
+  border: 1px solid #f4b1b0;
+  background-color: #f2dede;
+  color: #862422;
+  height: 30px;
+}
+.org-alert-warning .icon{
+  float: left;
+  color: #f2dede;
+  border-radius: 54px;
+  border: 1px solid #f4b1b0;
+  background-color: orange;
+  width: 14px;
+  margin: 6px 7px;
+  padding-left: 10px;
+  font-size: 12px;
+}
+.org-alert-warning .msg{
   float:left;
   padding: 7px;
 }

--- a/server/sonar-web/src/main/js/components/ui/NavBarTabs.css
+++ b/server/sonar-web/src/main/js/components/ui/NavBarTabs.css
@@ -76,16 +76,16 @@
   padding: 7px;
 }
 .org-alert-warning{
-  border: 1px solid #f4b1b0;
-  background-color: #f2dede;
-  color: #862422;
+  border: 1px solid #faebcc;
+  background-color: #fcf8e3;
+  color: #6f4f17;
   height: 30px;
 }
 .org-alert-warning .icon{
   float: left;
-  color: #f2dede;
+  color: #db781a;
   border-radius: 54px;
-  border: 1px solid #f4b1b0;
+  border: 1px solid #faebcc;
   background-color: orange;
   width: 14px;
   margin: 6px 7px;

--- a/server/sonar-web/src/main/js/types/types.ts
+++ b/server/sonar-web/src/main/js/types/types.ts
@@ -868,3 +868,8 @@ export interface OrganizationBase {
 export interface OrganizationMember extends UserActive {
   groupCount?: number;
 }
+
+export interface Notification {
+  type: string
+  message: string
+}


### PR DESCRIPTION
[CD-4953] Support for showing multiple codescan notifications (errors / notifications) and added logic to show only errors when both errors and warnings are present. Also refactor the API contract response for _codescan/notifications.

Kindly don't merge it until the required branches from codescan are merged.
