### PR TITLE
CD-3430 SQ fix for file comparison-#67070

### DIFF
--- a/codescan-application/build.gradle
+++ b/codescan-application/build.gradle
@@ -149,7 +149,7 @@ task zip(type: Zip, dependsOn: [configurations.compileClasspath]) {
 // Check the size of the archive
 zip.doLast {
   def minLength = 205000000
-  def maxLength = 260000000
+  def maxLength = 300000000
 
   def length = archiveFile.get().asFile.length()
   if (length < minLength)


### PR DESCRIPTION
When Compute Engine processes the analysis report for Comparison branches / Pull requests - it computes the difference between the original sequence and the revised sequence of each source file from PR. The results of these computations you can see on the Sources page of the Pull request analysis (new/removed/added lines).

The downside of this Sonarqube feature is the diff algorithm complexity which is about O(N*N) in worst cases, where is N - sum of lines of original and revised versions of file.

Unfortunately the Sonarqube doesn't have alternative implementations for the diff algorithms. 

To avoid this scenario, we need to skip new Line computation in case of huge difference in lines of code between 2 scans. 
