### PR TITLE
CF-60 Project Key Length

### DIFF
--- a/server/sonar-web/src/main/js/helpers/constants.ts
+++ b/server/sonar-web/src/main/js/helpers/constants.ts
@@ -54,7 +54,7 @@ export const RATING_COLORS = [
   { fill: colors.error400, fillTransparent: colors.error400a20, stroke: colors.error700 },
 ];
 
-export const PROJECT_KEY_MAX_LEN = 400;
+export const PROJECT_KEY_MAX_LEN = 255;
 
 export const ALM_DOCUMENTATION_PATHS = {
   [AlmKeys.Azure]: 'https://knowledgebase.autorabit.com/codescan/docs',

--- a/sonar-core/src/main/java/org/sonar/core/component/ComponentKeys.java
+++ b/sonar-core/src/main/java/org/sonar/core/component/ComponentKeys.java
@@ -30,7 +30,7 @@ public final class ComponentKeys {
   /**
    * Should be in sync with DefaultIndexedFile.MAX_KEY_LENGTH
    */
-  public static final int MAX_COMPONENT_KEY_LENGTH = 400;
+  public static final int MAX_COMPONENT_KEY_LENGTH = 255;
 
   public static final String ALLOWED_CHARACTERS_MESSAGE = "Allowed characters are alphanumeric, '-', '_', '.' and ':', with at least one non-digit";
 

--- a/sonar-core/src/main/java/org/sonar/core/component/ComponentKeys.java
+++ b/sonar-core/src/main/java/org/sonar/core/component/ComponentKeys.java
@@ -30,7 +30,7 @@ public final class ComponentKeys {
   /**
    * Should be in sync with DefaultIndexedFile.MAX_KEY_LENGTH
    */
-  public static final int MAX_COMPONENT_KEY_LENGTH = 255;
+  public static final int MAX_COMPONENT_KEY_LENGTH = 400;
 
   public static final String ALLOWED_CHARACTERS_MESSAGE = "Allowed characters are alphanumeric, '-', '_', '.' and ':', with at least one non-digit";
 


### PR DESCRIPTION
Currently, project keys typed in the UI are limited to 20 characters.  Project keys added from outside the UI can be much longer.

This is blocking the VA when they are trying to create custom project keys to automatically assign permissions templates to projects.

The project keys in the UI should be able to be added with the same length in the UI as is allowed in the database.