### PR TITLE
CD-6005 Project analysis is not working if we are giving the project key of 255 characters from project management page

### DIFF
--- a/server/sonar-web/src/main/js/api/components.ts
+++ b/server/sonar-web/src/main/js/api/components.ts
@@ -169,6 +169,7 @@ export function getDirectories(data: GetTreeParams) {
 }
 
 export function getComponentData(data: { component: string } & BranchParameters): Promise<any> {
+  data.component = decodeURIComponent(data.component);
   return getJSON('/api/components/show', data);
 }
 

--- a/server/sonar-web/src/main/js/api/navigation.ts
+++ b/server/sonar-web/src/main/js/api/navigation.ts
@@ -26,6 +26,7 @@ import { Extension, NavigationComponent } from '../types/types';
 export function getComponentNavigation(
   data: { component: string } & BranchParameters
 ): Promise<NavigationComponent> {
+  data.component = decodeURIComponent(data.component);
   return getJSON('/api/navigation/component', data).catch(throwGlobalError);
 }
 


### PR DESCRIPTION

Issue is occuring when we include ":" in project key and proper decoding is not happening.
Two api calls that were involved in this issue:

1. /api/components/show
2. /api/navigation/component