### PR TITLE
CD-6011_latest increased component Key max length =999

### DIFF
--- a/sonar-core/src/main/java/org/sonar/core/component/ComponentKeys.java
+++ b/sonar-core/src/main/java/org/sonar/core/component/ComponentKeys.java
@@ -30,7 +30,7 @@ public final class ComponentKeys {
   /**
    * Should be in sync with DefaultIndexedFile.MAX_KEY_LENGTH
    */
-  public static final int MAX_COMPONENT_KEY_LENGTH = 400;
+  public static final int MAX_COMPONENT_KEY_LENGTH = 999;
 
   public static final String ALLOWED_CHARACTERS_MESSAGE = "Allowed characters are alphanumeric, '-', '_', '.' and ':', with at least one non-digit";
 

--- a/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/fs/internal/DefaultIndexedFile.java
+++ b/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/fs/internal/DefaultIndexedFile.java
@@ -39,7 +39,7 @@ import org.sonar.api.utils.PathUtils;
 @Immutable
 public class DefaultIndexedFile extends DefaultInputComponent implements IndexedFile {
   // should match limit in org.sonar.core.component.ComponentKeys
-  private static final Integer MAX_KEY_LENGTH = 400;
+  private static final Integer MAX_KEY_LENGTH = 999;
   private static final AtomicInteger intGenerator = new AtomicInteger(0);
 
   private final String projectRelativePath;


### PR DESCRIPTION

component key : ProjectKey+filePath (directory from root) .  so, componentKey <=400. but, we should consider giving projectKey(accordingly) + filePath (variable everytime) <=400 to make it work. increased Component Key to 999 (max value).