### PR TITLE
CD-6004 Retention Period fix

### DIFF
--- a/server/sonar-web/src/main/js/apps/projectBranches/components/LifetimeInformation.tsx
+++ b/server/sonar-web/src/main/js/apps/projectBranches/components/LifetimeInformation.tsx
@@ -23,10 +23,12 @@ import withAppStateContext from '../../../app/components/app-state/withAppStateC
 import { AppState } from '../../../types/appstate';
 import { SettingsKey } from '../../../types/settings';
 import LifetimeInformationRenderer from './LifetimeInformationRenderer';
+import { Component } from '../../../types/types';
 
 interface Props {
   comparisonBranchesEnabled: boolean;
   appState: AppState;
+  component: Component;
 }
 
 interface State {
@@ -48,7 +50,10 @@ export class LifetimeInformation extends React.PureComponent<Props, State> {
   }
 
   fetchBranchAndPullRequestLifetimeSetting() {
-    getValue({ key: SettingsKey.DaysBeforeDeletingInactiveBranchesAndPRs }).then(
+    getValue({
+      key: SettingsKey.DaysBeforeDeletingInactiveBranchesAndPRs,
+      component: this.props.component.key,
+    }).then(
       (settings) => {
         if (this.mounted) {
           this.setState({

--- a/server/sonar-web/src/main/js/apps/projectBranches/components/ProjectBranchesApp.tsx
+++ b/server/sonar-web/src/main/js/apps/projectBranches/components/ProjectBranchesApp.tsx
@@ -45,7 +45,10 @@ export function ProjectBranchesApp(props: ProjectBranchesAppProps) {
                 : translate('project_branch_pull_request.page')
           }
         </h1>
-        <LifetimeInformation comparisonBranchesEnabled={props.comparisonBranchesEnabled}/>
+        <LifetimeInformation
+          comparisonBranchesEnabled={props.comparisonBranchesEnabled}
+          component={component}
+        />
       </header>
 
       <BranchLikeTabs


### PR DESCRIPTION
The retention period for project branches in CodeScan is not functioning properly.

The UI is able to be set but it does not affect the clean up of branches within the project.

This setting can be found in Project Settings > General Settings > Housekeeping > Delete inactive branches and PRs after..

There is also text in the branches menu that does not reflect the branch retention length change:

![image](https://github.com/user-attachments/assets/a3a830e3-247f-494c-8c1d-9b02556100ce)
