### PR TITLE
CD-6330 fix for org param missing for qualityGatesPage

### DIFF
--- a/server/sonar-web/src/main/js/apps/quality-gates/components/DetailsHeader.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-gates/components/DetailsHeader.tsx
@@ -65,7 +65,7 @@ export default function DetailsHeader({ organization, qualityGate }: Readonly<Pr
   const { mutateAsync: setAiSupportedQualityGate } = useSetAiSupportedQualityGateMutation();
   const { data: qualityGateProjectsHavingAiCode = [], isLoading: isCountLoading } =
     useGetAllQualityGateProjectsQuery(
-      { gateName: qualityGate.name, selected: 'selected' },
+      { organization, gateName: qualityGate.name, selected: 'selected' },
       {
         select: (data) =>
           data.results.filter((p) => p.aiCodeAssurance === AiCodeAssuranceStatus.AI_CODE_ASSURED),


### PR DESCRIPTION
User should be logged into CodeScan application and should be on any Org.

Click on Quality Gates tab then user will navigate to Quality Gates page and able to see the error message The 'organization' parameter is missing with Status Code: 400 Bad Request 
