### PR TITLE
CD-6331 fix for org param missing for QualityProfileCreation

### DIFF
--- a/server/sonar-web/src/main/js/apps/coding-rules/components/RuleDetails.tsx
+++ b/server/sonar-web/src/main/js/apps/coding-rules/components/RuleDetails.tsx
@@ -153,7 +153,7 @@ export default function RuleDetails(props: Readonly<Props>) {
                     <Button
                       className="sw-ml-2 js-delete"
                       id="coding-rules-detail-rule-delete"
-                      onClick={() => deleteRule({ key: ruleKey })}
+                      onClick={() => deleteRule({ key: ruleKey, organization :organization })}
                       variety={ButtonVariety.DangerOutline}
                     >
                       {translate('delete')}


### PR DESCRIPTION
User should be logged into CodeScan application and should be on any org.

    Click on Quality Profile, user will navigate to Quality Profile page.

    Now, click on Create button for QP a pop-up will displayed for creating New Quality Profile.

    Select any one of the option and enter the QP name then user is able to see the error message The 'organization' parameter is missing with Status code: 400 bad request