### PR TITLE
CD-6365 Getting The component cannot be loaded. Try again later. if user clicks on the project which is not analyzed.

### DIFF
--- a/server/sonar-web/src/main/js/apps/overview/components/EmptyOverview.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/components/EmptyOverview.tsx
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Spinner } from '@sonarsource/echoes-react';
+import { Link,  Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { FlagMessage, LargeCenteredLayout, PageContentFontWrapper } from '~design-system';
 import { isBranch, isMainBranch } from '~sonar-aligned/helpers/branch-like';


### PR DESCRIPTION
User should be logged into CodeScan application and should be on any org.

Create a project from Projects Management.

Now, click on the Project which was created and was not analyzed.

User will navigate to Project overview page where user is able to see the error message as The component cannot be loaded. Try again later.

Generally if user clicks on project which is not analyzed then below page should be displayed