### PR TITLE
CD-6377 organization parameter is missing if user clicks on See Change log option for any Quality Profile

### DIFF
--- a/server/sonar-web/src/main/js/api/quality-profiles.ts
+++ b/server/sonar-web/src/main/js/api/quality-profiles.ts
@@ -200,6 +200,7 @@ interface ChangelogData {
   profile: Profile;
   since: string;
   to: string;
+  organization: string;
 }
 
 export function getProfileChangelog(data: ChangelogData): Promise<ChangelogResponse> {

--- a/server/sonar-web/src/main/js/apps/quality-profiles/changelog/ChangelogContainer.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/changelog/ChangelogContainer.tsx
@@ -39,7 +39,7 @@ interface Props {
 }
 
 function ChangelogContainer(props: Readonly<Props>) {
-  const { profile } = props;
+  const { profile, organization } = props;
   const { data: isStandardMode } = useStandardExperienceModeQuery();
   const router = useRouter();
   const {
@@ -59,13 +59,14 @@ function ChangelogContainer(props: Readonly<Props>) {
     to,
     profile,
     filterMode,
+    organization,
   });
 
   const events = changeLogResponse?.pages.flatMap((page) => page.events) ?? [];
   const total = changeLogResponse?.pages[0].paging.total;
 
   const handleDateRangeChange = ({ from, to }: { from?: Date; to?: Date }) => {
-    const path = getProfileChangelogPath(profile.name, profile.language, this.props.organization, {
+    const path = getProfileChangelogPath(profile.name, profile.language, organization, {
       since: from && toISO8601WithOffsetString(from),
       to: to && toISO8601WithOffsetString(to),
     });
@@ -73,7 +74,7 @@ function ChangelogContainer(props: Readonly<Props>) {
   };
 
   const handleReset = () => {
-    const path = getProfileChangelogPath(profile.name, profile.language, this.props.organization);
+    const path = getProfileChangelogPath(profile.name, profile.language, organization);
     router.replace(path);
   };
 
@@ -95,7 +96,9 @@ function ChangelogContainer(props: Readonly<Props>) {
 
       {isDefined(events) && events.length === 0 && <ChangelogEmpty />}
 
-      {isDefined(events) && events.length > 0 && <Changelog events={events} organization={this.props.organization} />}
+      {isDefined(events) && events.length > 0 && (
+        <Changelog events={events} organization={organization} />
+      )}
 
       {shouldDisplayFooter && (
         <footer className="sw-text-center sw-mt-2">


### PR DESCRIPTION
User should be logged into CodeScan application and should be on any organisation.

Click on Quality Profiles user will navigate to QP page

Now click on any QP of any language, user will navigate to the QP page where user can see the Active rule and also the option where user can see the See Change log option where user can see the rules which are activated and deactivated according to the dates mentioned.

If user click on See Change log option user is able to see the error message as {"errors":[{"msg":"The \u0027organization\u0027 parameter is missing"}]} with Status Code:

400 Bad Request

 Request URL:

https://preview.codescan.io/api/qualityprofiles/changelog?language=sf&qualityProfile=apex-10.8&filterMode=STANDARD&p=1