### PR TITLE
CD-6397 Metlife - Categories for Project Types

### DIFF
--- a/server/sonar-web/src/main/js/apps/projectInformation/about/components/MetaTags.tsx
+++ b/server/sonar-web/src/main/js/apps/projectInformation/about/components/MetaTags.tsx
@@ -28,6 +28,7 @@ import Tooltip from '../../../../components/controls/Tooltip';
 import { PopupPlacement } from '../../../../components/ui/popups';
 import { translate } from '../../../../helpers/l10n';
 import { Component } from '../../../../types/types';
+import { almTagsList } from '../../utils';
 
 interface Props {
   component: Component;
@@ -113,17 +114,21 @@ function MetaTagsSelector({ selectedTags, setProjectTags }: MetaTagsSelectorProp
       q: query,
       ps: Math.min(selectedTags.length - 1 + LIST_SIZE, MAX_LIST_SIZE),
     }).then(
-      ({ tags }) => setSearchResult(tags),
+      ({ tags }) => setSearchResult(tags.filter((item) => !almTagsList.includes(item))),
       () => {},
     );
   };
 
   const onSelect = (tag: string) => {
-    setProjectTags([...selectedTags, tag]);
+    if (!almTagsList.find((t) => t === tag)) {
+      setProjectTags([...selectedTags, tag]);
+    }
   };
 
   const onUnselect = (tag: string) => {
-    setProjectTags(without(selectedTags, tag));
+    if (!almTagsList.find((t) => t === tag)) {
+      setProjectTags(without(selectedTags, tag));
+    }
   };
 
   return (
@@ -136,7 +141,7 @@ function MetaTagsSelector({ selectedTags, setProjectTags }: MetaTagsSelectorProp
       onSelect={onSelect}
       onUnselect={onUnselect}
       selectedElements={selectedTags}
-      elements={availableTags}
+      elements={availableTags.filter((item) => !almTagsList.includes(item))}
     />
   );
 }

--- a/server/sonar-web/src/main/js/apps/projectInformation/constants.ts
+++ b/server/sonar-web/src/main/js/apps/projectInformation/constants.ts
@@ -1,0 +1,7 @@
+/* eslint-disable header/header */
+
+export const GITHUB_ALM_TAG = 'github';
+export const GITLAB_ALM_TAG = 'gitlab';
+export const GIT_ALM_TAG = 'git';
+export const BITBUCKET_ALM_TAG = 'bitbucket';
+export const SALESFORCE_ALM_TAG = 'salesforce';

--- a/server/sonar-web/src/main/js/apps/projectInformation/utils.ts
+++ b/server/sonar-web/src/main/js/apps/projectInformation/utils.ts
@@ -1,0 +1,16 @@
+/* eslint-disable header/header */
+import {
+  BITBUCKET_ALM_TAG,
+  GIT_ALM_TAG,
+  GITHUB_ALM_TAG,
+  GITLAB_ALM_TAG,
+  SALESFORCE_ALM_TAG,
+} from './constants';
+
+export const almTagsList: string[] = [
+  GITHUB_ALM_TAG,
+  GITLAB_ALM_TAG,
+  GIT_ALM_TAG,
+  BITBUCKET_ALM_TAG,
+  SALESFORCE_ALM_TAG,
+];

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/projecttag/ws/AddActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/projecttag/ws/AddActionIT.java
@@ -1,0 +1,209 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.projecttag.ws;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.api.utils.System2;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.DbTester;
+import org.sonar.db.component.ComponentDto;
+import org.sonar.db.component.ProjectData;
+import org.sonar.db.project.ProjectDto;
+import org.sonar.server.component.TestComponentFinder;
+import org.sonar.server.es.TestIndexers;
+import org.sonar.server.exceptions.BadRequestException;
+import org.sonar.server.exceptions.NotFoundException;
+import org.sonar.server.projecttag.TagsWsSupport;
+import org.sonar.server.tester.UserSessionRule;
+import org.sonar.server.ws.TestRequest;
+import org.sonar.server.ws.TestResponse;
+import org.sonar.server.ws.WsActionTester;
+
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.sonar.db.component.ComponentDbTester.defaults;
+import static org.sonar.db.component.ComponentTesting.newFileDto;
+import static org.sonar.server.es.Indexers.EntityEvent.PROJECT_TAGS_UPDATE;
+
+public class AddActionIT {
+
+    @Rule
+    public UserSessionRule userSession = UserSessionRule.standalone().logIn();
+    @Rule
+    public DbTester db = DbTester.create();
+
+    private final DbClient dbClient = db.getDbClient();
+    private final DbSession dbSession = db.getSession();
+    private final TestIndexers indexers = new TestIndexers();
+    private final TagsWsSupport tagsWsSupport = new TagsWsSupport(dbClient, TestComponentFinder.from(db), userSession,
+            indexers, System2.INSTANCE);
+    private final WsActionTester ws = new WsActionTester(new AddAction(dbClient, tagsWsSupport));
+    private ProjectDto project;
+    private ComponentDto projectComponent;
+
+    @Before
+    public void setUp() {
+        ProjectData projectData = db.components().insertPrivateProject();
+        project = projectData.getProjectDto();
+        projectComponent = projectData.getMainBranchComponent();
+    }
+
+    @Test
+    public void addProjectTagsWithEmptyDbTags() {
+        TestResponse response = call(project.getKey(), "github");
+        assertTags(project.getKey(), Arrays.asList("github"));
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void addTags() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("project-tag,cs-project"))
+                .getProjectDto();
+        TestResponse response = call(project.getKey(), "github");
+        assertTags(project.getKey(), Arrays.asList("github", "project-tag", "cs-project"));
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void addTagsExcludeEmptyAndBlankValues() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("alm-project,cs-project"))
+                .getProjectDto();
+        TestResponse response = call(project.getKey(), "github,");
+        assertTags(project.getKey(), Arrays.asList("github", "alm-project", "cs-project"));
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void addDuplicateTagsWithExistingEntriesThenIgnoreDuplicates() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("alm-project,cs-project"))
+                .getProjectDto();
+        TestResponse response = call(project.getKey(), "github,alm-project,cs-project");
+        assertTags(project.getKey(), Arrays.asList("github", "alm-project", "cs-project"));
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void addEmptyTags() {
+        call(project.getKey(), "");
+
+        assertNoTags(project.getKey());
+    }
+
+    @Test
+    public void doNotDuplicateTags() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("alm-project,cs-project"))
+                .getProjectDto();
+        call(project.getKey(), "github,github,github");
+
+        assertTags(project.getKey(), Arrays.asList("github", "alm-project", "cs-project"));
+    }
+
+    @Test
+    public void addTagsInUppercaseThenUpdateToLowercase() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("alm-project,cs-project"))
+                .getProjectDto();
+        call(project.getKey(), "GITHUB,bitbucket");
+
+        assertTags(project.getKey(), Arrays.asList("github", "bitbucket", "alm-project", "cs-project"));
+    }
+
+    @Test
+    public void failIfTagDoesNotRespectFormat() {
+        String projectKey = project.getKey();
+        assertThatThrownBy(() -> call(projectKey, "_finance_"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(
+                        "Tag '_finance_' is invalid. Tags accept only the characters: a-z, 0-9, '+', '-', '#', '.'");
+    }
+
+    @Test
+    public void failIfNoProject() {
+        assertThatThrownBy(() -> call(null, "platform"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void failIfNoTags() {
+        String projectKey = project.getKey();
+        assertThatThrownBy(() -> call(projectKey, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void failIfComponentIsAView() {
+        ComponentDto view = db.components().insertPrivatePortfolio(v -> v.setKey("VIEW_KEY"));
+
+        String viewKey = view.getKey();
+        assertThatThrownBy(() -> call(viewKey, "point-of-view"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Project 'VIEW_KEY' not found");
+    }
+
+    @Test
+    public void failIfComponentIsAFile() {
+        ComponentDto file = db.components().insertComponent(newFileDto(projectComponent).setKey("FILE_KEY"));
+
+        String fileKey = file.getKey();
+        assertThatThrownBy(() -> call(fileKey, "secret"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Project 'FILE_KEY' not found");
+    }
+
+    @Test
+    public void definition() {
+        WebService.Action definition = ws.getDef();
+
+        assertThat(definition.isPost()).isTrue();
+        assertThat(definition.isInternal()).isFalse();
+        assertThat(definition.params()).extracting(WebService.Param::key)
+                .containsOnly("project", "tags");
+        assertThat(definition.description()).isNotEmpty();
+        assertThat(definition.since()).isEqualTo("10.8");
+    }
+
+    private TestResponse call(@Nullable String projectKey, @Nullable String tags) {
+        TestRequest request = ws.newRequest();
+        ofNullable(projectKey).ifPresent(p -> request.setParam("project", p));
+        ofNullable(tags).ifPresent(t -> request.setParam("tags", tags));
+
+        return request.execute();
+    }
+
+    private void assertTags(String projectKey, List<String> tags) {
+        assertThat(dbClient.projectDao().selectProjectByKey(dbSession, projectKey).get().getTags()).isEqualTo(tags);
+    }
+
+    private void assertNoTags(String projectKey) {
+        assertThat(dbClient.projectDao().selectProjectByKey(dbSession, projectKey).get().getTags()).isEmpty();
+    }
+}

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/projecttag/ws/RemoveActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/projecttag/ws/RemoveActionIT.java
@@ -1,0 +1,201 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.projecttag.ws;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.api.utils.System2;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.DbTester;
+import org.sonar.db.component.ComponentDto;
+import org.sonar.db.component.ProjectData;
+import org.sonar.db.project.ProjectDto;
+import org.sonar.server.component.TestComponentFinder;
+import org.sonar.server.es.TestIndexers;
+import org.sonar.server.exceptions.BadRequestException;
+import org.sonar.server.exceptions.NotFoundException;
+import org.sonar.server.projecttag.TagsWsSupport;
+import org.sonar.server.tester.UserSessionRule;
+import org.sonar.server.ws.TestRequest;
+import org.sonar.server.ws.TestResponse;
+import org.sonar.server.ws.WsActionTester;
+
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.sonar.db.component.ComponentDbTester.defaults;
+import static org.sonar.db.component.ComponentTesting.newFileDto;
+import static org.sonar.server.es.Indexers.EntityEvent.PROJECT_TAGS_UPDATE;
+
+public class RemoveActionIT {
+
+    @Rule
+    public UserSessionRule userSession = UserSessionRule.standalone().logIn();
+    @Rule
+    public DbTester db = DbTester.create();
+
+    private final DbClient dbClient = db.getDbClient();
+    private final DbSession dbSession = db.getSession();
+    private final TestIndexers indexers = new TestIndexers();
+    private final TagsWsSupport tagsWsSupport = new TagsWsSupport(dbClient, TestComponentFinder.from(db), userSession,
+            indexers, System2.INSTANCE);
+    private final WsActionTester ws = new WsActionTester(new RemoveAction(dbClient, tagsWsSupport));
+    private ProjectDto project;
+    private ComponentDto projectComponent;
+
+    @Before
+    public void setUp() {
+        ProjectData projectData = db.components().insertPrivateProject();
+        project = projectData.getProjectDto();
+        projectComponent = projectData.getMainBranchComponent();
+    }
+
+    @Test
+    public void removeTagsWhenExistingTagsAreEmptyThenReturnEmptyString() {
+        TestResponse response = call(project.getKey(), "github");
+        assertTags(project.getKey(), Arrays.asList());
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void removeMultipleTags() {
+        project = db.components()
+                .insertPrivateProject(defaults(), p -> p.setTagsString("github,project-tag,cs-project"))
+                .getProjectDto();
+        TestResponse response = call(project.getKey(), "github,cs-project");
+        assertTags(project.getKey(), Arrays.asList("project-tag"));
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void removeTagsExcludeEmptyAndBlankValues() {
+        project = db.components()
+                .insertPrivateProject(defaults(), p -> p.setTagsString("github,project-tag,cs-project"))
+                .getProjectDto();
+        TestResponse response = call(project.getKey(), "github,cs-project, ");
+        assertTags(project.getKey(), Arrays.asList("project-tag"));
+        indexers.hasBeenCalledForEntity(project.getUuid(), PROJECT_TAGS_UPDATE);
+        assertThat(response.getStatus()).isEqualTo(HTTP_NO_CONTENT);
+    }
+
+    @Test
+    public void removeEmptyTags() {
+        call(project.getKey(), "");
+
+        assertNoTags(project.getKey());
+    }
+
+    @Test
+    public void doNotDuplicateTags() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("github,alm-project,cs-project"))
+                .getProjectDto();
+        call(project.getKey(), "github,github,github");
+
+        assertTags(project.getKey(), Arrays.asList("alm-project", "cs-project"));
+    }
+
+    @Test
+    public void removeTagsInUppercaseThenUpdateToLowercase() {
+        project = db.components().insertPrivateProject(defaults(), p -> p.setTagsString("github,bitbucket,alm-project,cs-project"))
+                .getProjectDto();
+        call(project.getKey(), "GITHUB,bitbucket");
+
+        assertTags(project.getKey(), Arrays.asList("alm-project", "cs-project"));
+    }
+
+    @Test
+    public void failIfTagDoesNotRespectFormat() {
+        String projectKey = project.getKey();
+        assertThatThrownBy(() -> call(projectKey, "_finance_"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(
+                        "Tag '_finance_' is invalid. Tags accept only the characters: a-z, 0-9, '+', '-', '#', '.'");
+    }
+
+    @Test
+    public void failIfNoProject(){
+        assertThatThrownBy(() -> call(null, "platform"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void failIfNoTags() {
+        String projectKey = project.getKey();
+        assertThatThrownBy(() -> call(projectKey, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void failIfComponentIsAView() {
+        ComponentDto view = db.components().insertPrivatePortfolio(v -> v.setKey("VIEW_KEY"));
+
+        String viewKey = view.getKey();
+        assertThatThrownBy(() -> call(viewKey, "point-of-view"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Project 'VIEW_KEY' not found");
+    }
+
+    @Test
+    public void failIfComponentIsAFile() {
+        ComponentDto file = db.components().insertComponent(newFileDto(projectComponent).setKey("FILE_KEY"));
+
+        String fileKey = file.getKey();
+        assertThatThrownBy(() -> call(fileKey, "secret"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Project 'FILE_KEY' not found");
+    }
+
+    @Test
+    public void definition() {
+        WebService.Action definition = ws.getDef();
+
+        assertThat(definition.isPost()).isTrue();
+        assertThat(definition.isInternal()).isFalse();
+        assertThat(definition.params()).extracting(WebService.Param::key)
+                .containsOnly("project", "tags");
+        assertThat(definition.description()).isNotEmpty();
+        assertThat(definition.since()).isEqualTo("10.8");
+    }
+
+    private TestResponse call(@Nullable String projectKey, @Nullable String tags) {
+        TestRequest request = ws.newRequest();
+        ofNullable(projectKey).ifPresent(p -> request.setParam("project", p));
+        ofNullable(tags).ifPresent(t -> request.setParam("tags", tags));
+
+        return request.execute();
+    }
+
+    private void assertTags(String projectKey, List<String> tags) {
+        assertThat(dbClient.projectDao().selectProjectByKey(dbSession, projectKey).get().getTags()).isEqualTo(tags);
+    }
+
+    private void assertNoTags(String projectKey) {
+        assertThat(dbClient.projectDao().selectProjectByKey(dbSession, projectKey).get().getTags()).isEmpty();
+    }
+}

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/TagsWsSupport.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/TagsWsSupport.java
@@ -71,7 +71,7 @@ public class TagsWsSupport {
     List<String> updatedTags = new ArrayList<>(validatedTags);
     updatedTags.addAll(project.getTags());
     updatedTags = updatedTags.stream().distinct().collect(Collectors.toList());
-    updateTagsForProjectsOrApplicationBypassPermissions(dbSession, updatedTags, project);
+    updateTagsForProjectsOrApplicationForAllUsers(dbSession, updatedTags, project);
   }
 
   public void removeProjectTags(DbSession dbSession, String projectKey, List<String> providedTags) {
@@ -79,7 +79,7 @@ public class TagsWsSupport {
     List<String> validatedTags = checkAndUnifyTags(providedTags);
     List<String> updatedTags = new ArrayList<>(project.getTags());
     updatedTags.removeAll(validatedTags);
-    updateTagsForProjectsOrApplicationBypassPermissions(dbSession, updatedTags, project);
+    updateTagsForProjectsOrApplicationForAllUsers(dbSession, updatedTags, project);
   }
 
   public void updateApplicationTags(DbSession dbSession, String applicationKey, List<String> providedTags) {
@@ -93,7 +93,7 @@ public class TagsWsSupport {
     updateTags(dbSession, tags, projectOrApplication);
   }
 
-  private void updateTagsForProjectsOrApplicationBypassPermissions(DbSession dbSession, List<String> validatedTags,
+  private void updateTagsForProjectsOrApplicationForAllUsers(DbSession dbSession, List<String> validatedTags,
           ProjectDto projectOrApplication) {
     updateTags(dbSession, validatedTags, projectOrApplication);
   }

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/TagsWsSupport.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/TagsWsSupport.java
@@ -19,9 +19,11 @@
  */
 package org.sonar.server.projecttag;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.utils.System2;
 import org.sonar.api.web.UserRole;
@@ -63,6 +65,23 @@ public class TagsWsSupport {
     updateTagsForProjectsOrApplication(dbSession, validatedTags, project);
   }
 
+  public void addProjectTags(DbSession dbSession, String projectKey, List<String> providedTags) {
+    ProjectDto project = componentFinder.getProjectByKey(dbSession, projectKey);
+    List<String> validatedTags = checkAndUnifyTags(providedTags);
+    List<String> updatedTags = new ArrayList<>(validatedTags);
+    updatedTags.addAll(project.getTags());
+    updatedTags = updatedTags.stream().distinct().collect(Collectors.toList());
+    updateTagsForProjectsOrApplicationBypassPermissions(dbSession, updatedTags, project);
+  }
+
+  public void removeProjectTags(DbSession dbSession, String projectKey, List<String> providedTags) {
+    ProjectDto project = componentFinder.getProjectByKey(dbSession, projectKey);
+    List<String> validatedTags = checkAndUnifyTags(providedTags);
+    List<String> updatedTags = new ArrayList<>(project.getTags());
+    updatedTags.removeAll(validatedTags);
+    updateTagsForProjectsOrApplicationBypassPermissions(dbSession, updatedTags, project);
+  }
+
   public void updateApplicationTags(DbSession dbSession, String applicationKey, List<String> providedTags) {
     List<String> validatedTags = checkAndUnifyTags(providedTags);
     ProjectDto application = componentFinder.getApplicationByKey(dbSession, applicationKey);
@@ -71,6 +90,15 @@ public class TagsWsSupport {
 
   private void updateTagsForProjectsOrApplication(DbSession dbSession, List<String> tags, ProjectDto projectOrApplication) {
     userSession.checkEntityPermission(UserRole.ADMIN, projectOrApplication);
+    updateTags(dbSession, tags, projectOrApplication);
+  }
+
+  private void updateTagsForProjectsOrApplicationBypassPermissions(DbSession dbSession, List<String> validatedTags,
+          ProjectDto projectOrApplication) {
+    updateTags(dbSession, validatedTags, projectOrApplication);
+  }
+
+  private void updateTags(DbSession dbSession, List<String> tags, ProjectDto projectOrApplication) {
     projectOrApplication.setTags(tags);
     projectOrApplication.setUpdatedAt(system2.now());
     dbClient.projectDao().updateTags(dbSession, projectOrApplication);

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/AddAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/AddAction.java
@@ -1,0 +1,49 @@
+package org.sonar.server.projecttag.ws;
+
+import java.util.List;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.server.projecttag.TagsWsSupport;
+
+import static org.sonar.server.ws.KeyExamples.KEY_PROJECT_EXAMPLE_001;
+
+public class AddAction implements ProjectTagsWsAction {
+
+    private static final String PARAM_PROJECT = "project";
+    private static final String PARAM_TAGS = "tags";
+
+    private final DbClient dbClient;
+    private final TagsWsSupport tagsWsSupport;
+
+    public AddAction(DbClient dbClient, TagsWsSupport tagsWsSupport) {
+        this.dbClient = dbClient;
+        this.tagsWsSupport = tagsWsSupport;
+    }
+
+    @Override
+    public void define(WebService.NewController context) {
+        WebService.NewAction action = context.createAction("add").setDescription("Add tags on a project.")
+                .setSince("10.8").setPost(true).setHandler(this);
+
+        action.createParam(PARAM_PROJECT).setDescription("Project key").setRequired(true)
+                .setExampleValue(KEY_PROJECT_EXAMPLE_001);
+
+        action.createParam(PARAM_TAGS).setDescription("Comma-separated list of tags").setRequired(true)
+                .setExampleValue("finance, offshore");
+    }
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        String projectKey = request.mandatoryParam(PARAM_PROJECT);
+        List<String> tags = request.mandatoryParamAsStrings(PARAM_TAGS);
+
+        try (DbSession dbSession = dbClient.openSession(false)) {
+            tagsWsSupport.addProjectTags(dbSession, projectKey, tags);
+        }
+
+        response.noContent();
+    }
+}

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/AddAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/AddAction.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.server.projecttag.ws;
 
 import java.util.List;

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/ProjectTagsWsModule.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/ProjectTagsWsModule.java
@@ -29,7 +29,9 @@ public class ProjectTagsWsModule extends Module {
       TagsWsSupport.class,
       ProjectTagsWs.class,
       SetAction.class,
-      SearchAction.class
+      SearchAction.class,
+      AddAction.class,
+      RemoveAction.class
     );
   }
 }

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/RemoveAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/projecttag/ws/RemoveAction.java
@@ -1,0 +1,68 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.projecttag.ws;
+
+import static org.sonar.server.ws.KeyExamples.KEY_PROJECT_EXAMPLE_001;
+
+import java.util.List;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.server.projecttag.TagsWsSupport;
+
+public class RemoveAction implements ProjectTagsWsAction {
+
+    private static final String PARAM_PROJECT = "project";
+    private static final String PARAM_TAGS = "tags";
+
+    private final DbClient dbClient;
+    private final TagsWsSupport tagsWsSupport;
+
+    public RemoveAction(DbClient dbClient, TagsWsSupport tagsWsSupport) {
+        this.dbClient = dbClient;
+        this.tagsWsSupport = tagsWsSupport;
+    }
+
+    @Override
+    public void define(WebService.NewController context) {
+        WebService.NewAction action = context.createAction("remove").setDescription("Remove tags on a project.")
+                .setSince("10.8").setPost(true).setHandler(this);
+
+        action.createParam(PARAM_PROJECT).setDescription("Project key").setRequired(true)
+                .setExampleValue(KEY_PROJECT_EXAMPLE_001);
+
+        action.createParam(PARAM_TAGS).setDescription("Comma-separated list of tags").setRequired(true)
+                .setExampleValue("finance, offshore");
+    }
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        String projectKey = request.mandatoryParam(PARAM_PROJECT);
+        List<String> tags = request.mandatoryParamAsStrings(PARAM_TAGS);
+
+        try (DbSession dbSession = dbClient.openSession(false)) {
+            tagsWsSupport.removeProjectTags(dbSession, projectKey, tags);
+        }
+
+        response.noContent();
+    }
+}

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/projecttags/AddProjectTagsRequest.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/projecttags/AddProjectTagsRequest.java
@@ -1,0 +1,54 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarqube.ws.client.projecttags;
+
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated("sonar-ws-generator")
+public class AddProjectTagsRequest {
+
+    private String project;
+    private List<String> tags;
+
+    /**
+     * This is a mandatory parameter. Example value: "my_project"
+     */
+    public AddProjectTagsRequest setProject(String project) {
+        this.project = project;
+        return this;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    /**
+     * This is a mandatory parameter. Example value: "finance, offshore"
+     */
+    public AddProjectTagsRequest setTag(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+}

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/projecttags/ProjectTagsService.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/projecttags/ProjectTagsService.java
@@ -22,11 +22,11 @@ package org.sonarqube.ws.client.projecttags;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 import org.sonarqube.ws.MediaTypes;
+import org.sonarqube.ws.ProjectTags.SearchResponse;
 import org.sonarqube.ws.client.BaseService;
 import org.sonarqube.ws.client.GetRequest;
 import org.sonarqube.ws.client.PostRequest;
 import org.sonarqube.ws.client.WsConnector;
-import org.sonarqube.ws.ProjectTags.SearchResponse;
 
 /**
  * @see <a href="https://next.sonarqube.com/sonarqube/web_api/api/project_tags">Further information about this web service online</a>
@@ -68,4 +68,17 @@ public class ProjectTagsService extends BaseService {
         .setMediaType(MediaTypes.JSON)
       ).content();
   }
+
+  public void addProjectTags(AddProjectTagsRequest request) {
+    call(new PostRequest(path("add")).setParam("project", request.getProject())
+            .setParam("tags", request.getTags() == null ? null : request.getTags())
+            .setMediaType(MediaTypes.JSON)).content();
+  }
+
+  public void removeProjectTags(RemoveProjectTagsRequest request) {
+    call(new PostRequest(path("remove")).setParam("project", request.getProject())
+            .setParam("tags", request.getTags() == null ? null : request.getTags())
+            .setMediaType(MediaTypes.JSON)).content();
+  }
+
 }

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/projecttags/RemoveProjectTagsRequest.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/projecttags/RemoveProjectTagsRequest.java
@@ -1,0 +1,56 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarqube.ws.client.projecttags;
+
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated("sonar-ws-generator")
+public class RemoveProjectTagsRequest {
+
+    private String project;
+    private List<String> tags;
+
+    /**
+     * This is a mandatory parameter.
+     * Example value: "my_project"
+     */
+    public RemoveProjectTagsRequest setProject(String project) {
+        this.project = project;
+        return this;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    /**
+     * This is a mandatory parameter.
+     * Example value: "finance, offshore"
+     */
+    public RemoveProjectTagsRequest setTag(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+}


### PR DESCRIPTION
Metlife has a lot of projects.  They want to be able to filter their projects by the type of integration.

We need to be able to add tags on the project creation for our internal project integration types.  Those tags are:

GitHub: github
Bitbucket: bitbucket 
GitLab: gitlab
Git: git
Salesforce: salesforce

These tags need to be added with the creation of new projects.  We also need a way to retroactively add these to all of Metlife’s current projects.

Here are the tag API references: https://app.codescan.io/web_api/api/project_tags.