### PR TITLE
CD-6472 Webhook documentation link doesn't lead to any active knowledge base article

### DIFF
--- a/server/sonar-web/src/main/js/helpers/doc-links.ts
+++ b/server/sonar-web/src/main/js/helpers/doc-links.ts
@@ -74,7 +74,7 @@ export enum DocLink {
   ModeMQR = '/instance-administration/analysis-functions/instance-mode/mqr-mode',
   ModeStandard = '/instance-administration/analysis-functions/instance-mode/standard-experience',
   Monorepos = '/project-administration/monorepos/',
-  NewCodeDefinition = '/core-concepts/clean-as-you-code/about-new-code/',
+  NewCodeDefinition = '/product-guides/codescan/getting-started/setting-up-a-codescan-cloud-organization/understanding-the-new-code-tab',
   NewCodeDefinitionOptions = '/core-concepts/clean-as-you-code/about-new-code/#new-code-definition-options',
   Portfolios = '/user-guide/viewing-reports/portfolios/',
   PullRequestAnalysis = '/codescan/docs',
@@ -92,7 +92,7 @@ export enum DocLink {
   SonarScannerGradle = 'https://knowledgebase.autorabit.com/codescan/docs',
   SonarScannerMaven = 'https://knowledgebase.autorabit.com/codescan/docs',
   SonarWayQualityGate = '/user-guide/quality-gates/#using-sonar-way-the-recommended-quality-gate', // to be confirmed
-  Webhooks = '/codescan/docs/webhooks/',
+  Webhooks = '/product-guides/codescan/codescan-integration/webhooks',
   Documentation='/product-guides/codescan/codescan-overview/',
 }
 


### PR DESCRIPTION
jira story- https://autorabit.atlassian.net/browse/CD-6472

Issue 1:
In administration tab, when we click on webhooks, there's a "webhook documentation" link, it doesn't lead to any active page of knowledge base.

Issue 2:
In the Project Settings->General Settings->New code the [Defining New Code ](https://knowledgebase.autorabit.com/core-concepts/clean-as-you-code/about-new-code/)does not redirect to its correct page. Instead, it redirects to https://knowledgebase.autorabit.com/core-concepts/clean-as-you-code/about-new-code which results in “Page not found” error.
