### PR TITLE
CD-6474 Read more about analysis scope link redirects to page not found

### DIFF
--- a/server/sonar-web/src/main/js/apps/background-tasks/components/Header.tsx
+++ b/server/sonar-web/src/main/js/apps/background-tasks/components/Header.tsx
@@ -19,11 +19,10 @@
  */
 
 import { Title } from '~design-system';
-import DocumentationLink from '../../../components/common/DocumentationLink';
-import { DocLink } from '../../../helpers/doc-links';
 import { translate } from '../../../helpers/l10n';
 import { Component } from '../../../types/types';
 import Workers from './Workers';
+import { Link } from '@sonarsource/echoes-react';
 
 interface Props {
   component?: Component;
@@ -36,9 +35,10 @@ export default function Header(props: Readonly<Props>) {
         <Title className="sw-mb-4">{translate('background_tasks.page')}</Title>
         <p className="sw-max-w-3/4">
           {translate('background_tasks.page.description')}
-          <DocumentationLink className="sw-ml-2" to={DocLink.BackgroundTasks}>
+          <Link className="sw-ml-2" shouldOpenInNewTab={true}
+            to="https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/background-tasks/">
             {translate('learn_more')}
-          </DocumentationLink>
+          </Link>
         </p>
       </div>
       {!props.component && (

--- a/server/sonar-web/src/main/js/apps/background-tasks/components/Header.tsx
+++ b/server/sonar-web/src/main/js/apps/background-tasks/components/Header.tsx
@@ -19,10 +19,11 @@
  */
 
 import { Title } from '~design-system';
+import DocumentationLink from '../../../components/common/DocumentationLink';
+import { DocLink } from '../../../helpers/doc-links';
 import { translate } from '../../../helpers/l10n';
 import { Component } from '../../../types/types';
 import Workers from './Workers';
-import { Link } from '@sonarsource/echoes-react';
 
 interface Props {
   component?: Component;
@@ -35,10 +36,9 @@ export default function Header(props: Readonly<Props>) {
         <Title className="sw-mb-4">{translate('background_tasks.page')}</Title>
         <p className="sw-max-w-3/4">
           {translate('background_tasks.page.description')}
-          <Link className="sw-ml-2" shouldOpenInNewTab={true}
-            to="https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/background-tasks/">
+          <DocumentationLink className="sw-ml-2" to={DocLink.BackgroundTasks}>
             {translate('learn_more')}
-          </Link>
+          </DocumentationLink>
         </p>
       </div>
       {!props.component && (

--- a/server/sonar-web/src/main/js/helpers/doc-links.ts
+++ b/server/sonar-web/src/main/js/helpers/doc-links.ts
@@ -44,7 +44,7 @@ export enum DocLink {
   AlmGitLabIntegration = '/devops-platform-integration/gitlab-integration/introduction/',
   AlmSamlAuth = '/instance-administration/authentication/saml/overview/',
   AlmSamlScimAuth = '/instance-administration/authentication/saml/scim/overview/',
-  AnalysisScope = 'https://knowledgebase.autorabit.com/codescan/docs',
+  AnalysisScope = '/product-guides/codescan/report-and-analysis/analysis-scope-on-codescan-cloud',
   AuthOverview = 'https://knowledgebase.autorabit.com/codescan/docs',
   BackgroundTasks = '/codescan/docs/background-tasks',
   BranchAnalysis = 'https://knowledgebase.autorabit.com/codescan/docs',


### PR DESCRIPTION
Jira story - https://autorabit.atlassian.net/browse/CD-6474

Issue 1:
In the Project Settings->General Settings->Analysis Scope the Read more about analysis scope does not redirect to its correct page. Instead, it redirects to https://knowledgebase.autorabit.com/https:/knowledgebase.autorabit.com/codescan/docs which results in “Page not found” error.

Issue 2:
In the Project Settings->General Settings->Background tasks the [Learn More ](https://knowledgebase.autorabit.com/codescan/docs/background-tasks) does not redirect to its correct page. Instead, it redirects to https://knowledgebase.autorabit.com/codescan/docs/background-tasks which results in “Page not found” error.
