### PR TITLE
CD-6483 Added 'Comparision Branches' attribuite in core.properties

### DIFF
--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -5710,6 +5710,7 @@ branch_like_navigation.only_one_branch.content=Quickly set up branch analysis an
 branch_like_navigation.only_one_branch.documentation=Branches documentation
 branch_like_navigation.only_one_branch.pr_analysis=Pull Request analysis
 branch_like_navigation.tutorial_for_ci=Show me how to set up my CI
+branch_like_navigation.comparison_branches=Comparison Branches
 
 #------------------------------------------------------------------------------
 #


### PR DESCRIPTION
User should be logged into CodeScan application and should be on any org.

Select a SF analyzed project and create a comparison branch for the analyzed project. After completion of the analysis user should be able to see the branches under COMPARISON BRANCH but on TEST environment user is able to see the branch_like_navigation.comparison_branches instead of COMPARISON BRANCH.