### PR TITLE
CD-6501 User is Unable to see the changed severity type for the rule which is in Custom QP

### DIFF
--- a/server/sonar-web/src/main/js/apps/coding-rules/components/RuleListItem.tsx
+++ b/server/sonar-web/src/main/js/apps/coding-rules/components/RuleListItem.tsx
@@ -266,8 +266,8 @@ export default function RuleListItem(props: Readonly<Props>) {
         <div className="sw-flex sw-items-center">
           <div className="sw-grow sw-flex sw-gap-2 sw-items-center sw-typo-sm">
             <SoftwareImpactPillList
-              softwareImpacts={rule.impacts}
-              issueSeverity={rule.severity as IssueSeverity}
+              softwareImpacts={activation ? activation.impacts : rule.impacts}
+              issueSeverity={(activation ? activation.severity : rule.severity) as IssueSeverity}
               issueType={rule.type}
               type="rule"
             />


### PR DESCRIPTION
1. Launch and login to the codescan application and be on any org
2. Navigate to the quality profile page and copy any default QP 
3. Click on activate more and activate any rule by changing the severity 
4. But in the UI user is unable to see the changed severity which is not expected. 