### PR TITLE
CD-6529 If user add multiple tags on project information page then user is unable to see all the tags in the dropdown as scroll slide bar is missing

### DIFF
--- a/server/sonar-web/src/main/js/apps/projectInformation/about/components/MetaTags.tsx
+++ b/server/sonar-web/src/main/js/apps/projectInformation/about/components/MetaTags.tsx
@@ -127,16 +127,18 @@ function MetaTagsSelector({ selectedTags, setProjectTags }: MetaTagsSelectorProp
   };
 
   return (
-    <MultiSelector
-      headerLabel={translate('tags')}
-      searchInputAriaLabel={translate('search.search_for_tags')}
-      createElementLabel={translate('issue.create_tag')}
-      noResultsLabel={translate('no_results')}
-      onSearch={onSearch}
-      onSelect={onSelect}
-      onUnselect={onUnselect}
-      selectedElements={selectedTags}
-      elements={availableTags}
-    />
+    <div className="sw-max-h-abs-200 sw-overflow-y-auto">
+      <MultiSelector
+        headerLabel={translate('tags')}
+        searchInputAriaLabel={translate('search.search_for_tags')}
+        createElementLabel={translate('issue.create_tag')}
+        noResultsLabel={translate('no_results')}
+        onSearch={onSearch}
+        onSelect={onSelect}
+        onUnselect={onUnselect}
+        selectedElements={selectedTags}
+        elements={availableTags}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
Steps to reproduce:

1. Launch and login to the codescan application and be on any org
2. Navigate to the project analysis page under more tab
3. Open any analysed project and navigate to the project information tab
4. Click on tags and add and select tag to the project but if user wants to add multiple tags to the project it will be not possible as there is no scroll slide bar for tags dropdown.

