### PR TITLE
Fix QualityGateConditionsValidator bean error

### DIFF
--- a/server/sonar-server-common/src/main/java/org/sonar/server/issue/notification/NewModesNotificationsModule.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/issue/notification/NewModesNotificationsModule.java
@@ -31,7 +31,7 @@ public class NewModesNotificationsModule extends Module {
         */
 
 //      NewModesNotificationsSender.class,
-//      QualityGateConditionsValidator.class,
+      QualityGateConditionsValidator.class,
 //      MQRAndStandardModesExistNotification.class,
 //      MQRAndStandardModesExistNotificationHandler.class,
 //      MQRAndStandardModesExistTemplate.class,

--- a/server/sonar-webserver/src/main/java/org/sonar/server/platform/platformlevel/PlatformLevel4.java
+++ b/server/sonar-webserver/src/main/java/org/sonar/server/platform/platformlevel/PlatformLevel4.java
@@ -148,6 +148,7 @@ import org.sonar.server.issue.notification.MyNewIssuesEmailTemplate;
 import org.sonar.server.issue.notification.MyNewIssuesNotificationHandler;
 import org.sonar.server.issue.notification.NewIssuesEmailTemplate;
 import org.sonar.server.issue.notification.NewIssuesNotificationHandler;
+import org.sonar.server.issue.notification.NewModesNotificationsModule;
 import org.sonar.server.issue.ws.IssueWsModule;
 import org.sonar.server.language.LanguageValidation;
 import org.sonar.server.language.ws.LanguageWs;
@@ -541,7 +542,7 @@ public class PlatformLevel4 extends PlatformLevel {
       BuiltInQPChangeNotificationTemplate.class,
       BuiltInQPChangeNotificationHandler.class,
 
-      // new NewModesNotificationsModule(),
+      new NewModesNotificationsModule(),
       new NotificationModule(),
       new NotificationWsModule(),
       new EmailsWsModule(),


### PR DESCRIPTION
Fixed this issue:
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.sonar.server.qualitygate.QualityGateConditionsValidator' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}

