### PR TITLE
CD-6527 Getting unwanted error message while creating project from project management page

### DIFF
--- a/server/sonar-web/src/main/js/apps/projectsManagement/CreateProjectForm.tsx
+++ b/server/sonar-web/src/main/js/apps/projectsManagement/CreateProjectForm.tsx
@@ -63,17 +63,6 @@ export default function CreateProjectForm(props: Readonly<Props>) {
     setChangedParams({ ...changedParams, [name]: value });
   };
 
-  const handleError = (error: AxiosError<AxiosResponse>) => {
-    const { response } = error;
-    const message = parseErrorResponse(response);
-
-    if (!response || ![BAD_REQUEST, INTERNAL_SERVER_ERROR].includes(response.status)) {
-      addGlobalErrorMessage(message);
-    } else {
-      setError(message);
-    }
-  };
-
   const handleFormSubmit = (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -99,7 +88,6 @@ export default function CreateProjectForm(props: Readonly<Props>) {
           );
           props.onClose();
         },
-        onError: handleError
       },
     );
   };


### PR DESCRIPTION
Steps to reproduce:

1. Launch and login to the codescan application and be on any org
2. Navigate to the project management page under administration tab
3. Create a project with key which is already exist then user should be able to see the error message as
Could not create Project with key: "bb-test-1". A similar key already exists: "bb-test-1” 
it is expected but user is able to see the other error as
The request cannot be processed. Try again later. which is unexpected.