### PR TITLE
CD-6549 Unable to see the error message if user gives invalid character's in the Avatar and Url field on organisation settings page 

### DIFF
--- a/server/sonar-web/src/main/js/apps/create/components/OrganizationAvatarUrlInput.tsx
+++ b/server/sonar-web/src/main/js/apps/create/components/OrganizationAvatarUrlInput.tsx
@@ -18,9 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import classNames from 'classnames';
-import { FormField, InputField } from '~design-system';
 import * as React from 'react';
 import { isWebUri } from 'valid-url';
+import { FlagMessage, FormField, InputField } from '~design-system';
 import { throwGlobalError } from '~sonar-aligned/helpers/error';
 import withAppStateContext from '../../../../js/app/components/app-state/withAppStateContext';
 import { getWhiteListDomains } from '../../../api/organizations';
@@ -138,6 +138,11 @@ class OrganizationAvatarUrlInput extends React.PureComponent<Props, State> {
           type="text"
           value={this.state.value}
         />
+        {isInvalid && (
+          <FlagMessage id="avatar-url-error-message" className="sw-mt-2" variant="error">
+            {this.state.error}
+          </FlagMessage>
+        )}
       </FormField>
     );
   }

--- a/server/sonar-web/src/main/js/apps/create/components/OrganizationUrlInput.tsx
+++ b/server/sonar-web/src/main/js/apps/create/components/OrganizationUrlInput.tsx
@@ -18,9 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import classNames from 'classnames';
-import { FormField, InputField } from '~design-system';
 import * as React from 'react';
 import { isWebUri } from 'valid-url';
+import { FlagMessage, FormField, InputField } from '~design-system';
 import { throwGlobalError } from '~sonar-aligned/helpers/error';
 import withAppStateContext from '../../../../js/app/components/app-state/withAppStateContext';
 import { getWhiteListDomains } from '../../../api/organizations';
@@ -140,6 +140,11 @@ class OrganizationUrlInput extends React.PureComponent<Props, State> {
           type="text"
           value={this.state.value}
         />
+        {isInvalid && (
+          <FlagMessage id="url-error-message" className="sw-mt-2" variant="error">
+            {this.state.error}
+          </FlagMessage>
+        )}
       </FormField>
     );
   }


### PR DESCRIPTION
Steps to reproduce:

1. Launch and login to the codescan application and be on any org
2. Navigate to the organisation settings under administration tab 
3. Enter invalid character's in avatar field then user should be able to see error message as The value must be a valid url.

Issue 2:

Steps to reproduce:

1.  Launch and login to the codescan application and be on any org

2. Navigate to the organisation settings under administration tab 

3. Enter invalid character's in URL field then user should be able to see error message as The value must be a valid url.

