### PR TITLE
CD-6502 Restrict org admins to always have standard user type

### DIFF
--- a/server/sonar-web/src/main/js/types/types.ts
+++ b/server/sonar-web/src/main/js/types/types.ts
@@ -892,6 +892,7 @@ export interface OrganizationBase {
 export interface OrganizationMember extends UserActive {
   groupCount?: number;
   type: string;
+  isAdmin: boolean;
 }
 
 export interface Notification {

--- a/sonar-ws/src/main/protobuf/ws-organizations.proto
+++ b/sonar-ws/src/main/protobuf/ws-organizations.proto
@@ -94,6 +94,7 @@ message User {
   optional int32 groupCount = 4;
   optional string uuid = 5;
   optional string type = 6;
+  optional bool isAdmin = 7;
 }
 
 


### PR DESCRIPTION

Ensure that standard users who manage user access cannot switch their role to a Platform Integration User, so that user permissions are maintained correctly.

Preventing Standard users with System Admin Permission from switching to a Platform Integration User role will reduce potential misconfigurations and ensure compliance with user access policies. To enforce this, we should implement an alert and disable the option in the UI. This will give administrators better control over role assignments and prevent unintended access changes.

On the Members page, the following alert "You are a System Admin. You are required to have a Standard User License.“ should be displayed as shown in the attached image.