### PR TITLE
CD-6756 Quality Profiles - Incorrect Inactive Rule Counts

### DIFF
--- a/server/sonar-db-dao/src/main/java/org/sonar/db/rule/RuleDao.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/rule/RuleDao.java
@@ -320,6 +320,10 @@ public class RuleDao implements Dao {
     return mapper(dbSession).countByLanguage(language);
   }
 
+  public long countByLanguageInAnOrg(DbSession dbSession, String language, String organizationUuid) {
+    return mapper(dbSession).countByLanguageInAnOrg(language, organizationUuid);
+  }
+
   private static String toLowerCaseAndSurroundWithPercentSigns(@Nullable String query) {
     return isBlank(query) ? PERCENT_SIGN : (PERCENT_SIGN + query.toLowerCase(Locale.ENGLISH) + PERCENT_SIGN);
   }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/rule/RuleMapper.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/rule/RuleMapper.java
@@ -58,6 +58,8 @@ public interface RuleMapper {
 
   Long countByLanguage(@Param("language") String language);
 
+  Long countByLanguageInAnOrg(@Param("language") String language, @Param("organizationUuid") String organizationUuid);
+
   void insertRule(RuleDto ruleDefinitionDto);
 
   void insertRuleDescriptionSection(@Param("ruleUuid") String ruleUuid, @Param("dto") RuleDescriptionSectionDto ruleDescriptionSectionDto);

--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/rule/RuleMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/rule/RuleMapper.xml
@@ -368,6 +368,17 @@
     <include refid="conditionNotExternalRulesByLanguage" />
   </select>
 
+  <select id="countByLanguageInAnOrg" resultType="java.lang.Long">
+    select count(*)
+    from
+    rules r
+    where
+    r.status in ('READY', 'DEPRECATED', 'BETA')
+    and r.is_external=${_false}
+    and r.language=#{language, jdbcType=VARCHAR}
+    and (r.organization_uuid IS NULL OR r.organization_uuid = #{organizationUuid,jdbcType=VARCHAR});
+  </select>
+
   <sql id="conditionNotExternalRulesByLanguage">
     r.status in ('READY', 'DEPRECATED', 'BETA')
     and r.is_external=${_false}

--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/rule/RuleMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/rule/RuleMapper.xml
@@ -376,7 +376,7 @@
     r.status in ('READY', 'DEPRECATED', 'BETA')
     and r.is_external=${_false}
     and r.language=#{language, jdbcType=VARCHAR}
-    and (r.organization_uuid IS NULL OR r.organization_uuid = #{organizationUuid,jdbcType=VARCHAR});
+    and (r.organization_uuid IS NULL OR r.organization_uuid = #{organizationUuid,jdbcType=VARCHAR})
   </select>
 
   <sql id="conditionNotExternalRulesByLanguage">

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/qualityprofile/ws/InheritanceAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/qualityprofile/ws/InheritanceAction.java
@@ -156,7 +156,7 @@ public class InheritanceAction implements QProfileWsAction {
       ActiveRuleCountQuery.Builder builder = ActiveRuleCountQuery.builder().setOrganization(organization);
       countRulesByProfileKey = dao.countActiveRulesByQuery(dbSession, builder.setProfiles(profiles).build());
       countOverridingRulesByProfileKey = dao.countActiveRulesByQuery(dbSession, builder.setProfiles(profiles).setInheritance(OVERRIDES).build());
-      long totalRuleAvailable = dbClient.ruleDao().countByLanguage(dbSession, language);
+      long totalRuleAvailable = dbClient.ruleDao().countByLanguageInAnOrg(dbSession, language, organization.getUuid());
       profiles.forEach(p -> countInactiveRuleByProfileKey.put(p.getKee(), totalRuleAvailable - Optional.ofNullable(countRulesByProfileKey.get(p.getKee())).orElse(0L)));
     }
   }


### PR DESCRIPTION
When creating blank quality profiles, the count of the inactive rules is larger than the actual count of rules we have in that language.

To reproduce, create blank profiles for Apex, Visualforce and Salesforce Metadata and compare the full rule count for those languages to what is shown as inactive.