### PR TITLE
CD-6492-fix Refactored Elasticsearch filter to use orgUUIDs instead of projectUUIDs

### DIFF
--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueIndex.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueIndex.java
@@ -753,10 +753,10 @@ public class IssueIndex {
       filters.addFilter(
         FIELD_ISSUE_PROJECT_UUID, new SimpleFieldFilterScope(FIELD_ISSUE_PROJECT_UUID),
         createTermsFilter(FIELD_ISSUE_PROJECT_UUID, query.projectUuids()));
-      if (query.organizationUuid() != null && query.allowedProjectUuids() != null && !query.allowedProjectUuids().isEmpty()) {
+      if (query.organizationUuid() == null && query.allowedOrgUuids() != null && !query.allowedOrgUuids().isEmpty()) {
         filters.addFilter(
-                FIELD_ISSUE_PROJECT_UUID, new SimpleFieldFilterScope(FIELD_ISSUE_PROJECT_UUID),
-                QueryBuilders.termsQuery(FIELD_ISSUE_PROJECT_UUID, query.allowedProjectUuids())
+                FIELD_ISSUE_ORGANIZATION_UUID, new SimpleFieldFilterScope(FIELD_ISSUE_ORGANIZATION_UUID),
+                QueryBuilders.termsQuery(FIELD_ISSUE_ORGANIZATION_UUID, query.allowedOrgUuids())
         );}
       filters.addFilter(
         FIELD_ISSUE_DIRECTORY_PATH, new SimpleFieldFilterScope(FIELD_ISSUE_DIRECTORY_PATH),

--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueIndex.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueIndex.java
@@ -753,7 +753,7 @@ public class IssueIndex {
       filters.addFilter(
         FIELD_ISSUE_PROJECT_UUID, new SimpleFieldFilterScope(FIELD_ISSUE_PROJECT_UUID),
         createTermsFilter(FIELD_ISSUE_PROJECT_UUID, query.projectUuids()));
-      if (query.organizationUuid() == null && query.allowedOrgUuids() != null && !query.allowedOrgUuids().isEmpty()) {
+      if (StringUtils.isBlank(query.organizationUuid()) && query.allowedOrgUuids() != null && !query.allowedOrgUuids().isEmpty()) {
         filters.addFilter(
                 FIELD_ISSUE_ORGANIZATION_UUID, new SimpleFieldFilterScope(FIELD_ISSUE_ORGANIZATION_UUID),
                 QueryBuilders.termsQuery(FIELD_ISSUE_ORGANIZATION_UUID, query.allowedOrgUuids())

--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQuery.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQuery.java
@@ -109,7 +109,7 @@ public class IssueQuery {
 
   private final Collection<String> cvss;
 
-  private  final List<String> allowedProjectUuids;
+  private  final Collection<String> allowedOrgUuids;
 
   private IssueQuery(Builder builder) {
     this.issueKeys = nullableDefaultCollection(builder.issueKeys);
@@ -165,7 +165,7 @@ public class IssueQuery {
     this.organizationUuid = builder.organizationUuid;
     this.cvss = defaultCollection(builder.cvss);
  
-    this.allowedProjectUuids = builder.allowedProjectUuids;
+    this.allowedOrgUuids = builder.allowedOrgUuids;
   }
 
   public Collection<String> issueKeys() {
@@ -176,8 +176,8 @@ public class IssueQuery {
     return severities;
   }
 
-  public List<String> allowedProjectUuids() {
-    return allowedProjectUuids;
+  public Collection<String> allowedOrgUuids() {
+    return allowedOrgUuids;
   }
 
   public Collection<String> impactSeverities() {
@@ -460,7 +460,7 @@ public class IssueQuery {
     private Collection<String> cvss;
 
     private String organizationUuid;
-    private List<String> allowedProjectUuids; 
+    private Collection<String> allowedOrgUuids;
     
     private Builder() {
 
@@ -501,8 +501,8 @@ public class IssueQuery {
       return this;
     }
 
-    public Builder allowedProjectUuids(@Nullable Collection<String> l) {
-      this.projects = l;
+    public Builder allowedOrgUuids(@Nullable Collection<String> l) {
+      this.allowedOrgUuids = l;
       return this;
     }
 

--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQueryFactory.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQueryFactory.java
@@ -174,7 +174,7 @@ public class IssueQueryFactory {
         .organizationUuid(convertOrganizationKeyToUuid(dbSession, request.getOrganization()))
         .codeVariants(request.getCodeVariants())
         .cvss(request.getCvss());
-      if (request.getOrganization() == null) {
+      if (StringUtils.isBlank(request.getOrganization())) {
         builder.allowedOrgUuids(standardOrgs);
       }
 

--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQueryFactory.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQueryFactory.java
@@ -135,7 +135,6 @@ public class IssueQueryFactory {
 
       Set<String> standardOrgs = dbClient.organizationMemberDao().selectOrganizationUuidsByUserUuidAndType(
               dbSession, userSession.getUuid(),MemberType.STANDARD.name());
-      List<String> projectsList = dbClient.projectDao().selectProjectUuidsByOrganizationUuids(dbSession, (new ArrayList<String>( standardOrgs)));
       IssueQuery.Builder builder = IssueQuery.builder()
         .issueKeys(issueKeys)
         .severities(request.getSeverities())
@@ -176,7 +175,7 @@ public class IssueQueryFactory {
         .codeVariants(request.getCodeVariants())
         .cvss(request.getCvss());
       if (request.getOrganization() == null) {
-        builder.allowedProjectUuids(projectsList);
+        builder.allowedOrgUuids(standardOrgs);
       }
 
       List<ComponentDto> allComponents = new ArrayList<>();

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchAction.java
@@ -622,13 +622,7 @@ public class SearchAction implements IssuesWsAction {
     collectLoggedInUser(collector);
     collectRequestParams(collector, request);
     Facets facets = new Facets(result, Optional.ofNullable(query.timeZone()).orElse(system2.getDefaultTimeZone().toZoneId()));
-    if(!userSession.isRoot()){
-      Map<String, Long> projectsFacet = facets.get(FACET_PROJECTS);
-      if ( projectsFacet != null && query.organizationUuid() == null) {
-        Set<String> standardProjects = new HashSet<>(query.projectUuids());
-        projectsFacet.keySet().retainAll(standardProjects);
-      }
-    }
+
     if (!options.getFacets().isEmpty()) {
       // add missing values to facets. For example if assignee "john" and facet on "assignees" are requested, then
       // "john" should always be listed in the facet. If it is not present, then it is added with value zero.


### PR DESCRIPTION
Elasticsearch 'search too long' error is occurring when the list of project UUIDs is too large.