### PR TITLE
CD-7024 Salesforce AccountID for CodeScan Cloud

### DIFF
--- a/server/sonar-web/src/main/js/app/components/nav/global/GlobalNavUser.tsx
+++ b/server/sonar-web/src/main/js/app/components/nav/global/GlobalNavUser.tsx
@@ -53,16 +53,16 @@ export function GlobalNavUser({ currentUser, userOrganizations }: GlobalNavUserP
     const isCodescan = window.location.hostname.includes('codescan.io') || window.location.hostname.includes('autorabit.com');
     if (isLoggedIn(currentUser) && hasOrganizations && !pendoInitialized && isCodescan) {
       const script = document.createElement('script');
-      const sfAccountIds = userOrganizations.map(o => o.sfAccountId).join(',');
+      const sfAccountId = userOrganizations.find?.(o => o.sfAccountId != null)?.sfAccountId || null;
       const host = window.location.hostname;
-
+      
       script.innerHTML =
         "  pendo.initialize({\n" +
         "        visitor: {\n" +
         "          id: '" + (currentUser.email ? currentUser.email : currentUser.login) + "'\n" +
         "        },\n" +
         "        account: {\n" +
-        "          id: '" + sfAccountIds + "',\n" +
+        "          id: '" + sfAccountId + "',\n" +
         "          instance: '" + host + "'\n" +
         "        }\n" +
         "      });";

--- a/server/sonar-web/src/main/js/app/components/nav/global/GlobalNavUser.tsx
+++ b/server/sonar-web/src/main/js/app/components/nav/global/GlobalNavUser.tsx
@@ -53,7 +53,7 @@ export function GlobalNavUser({ currentUser, userOrganizations }: GlobalNavUserP
     const isCodescan = window.location.hostname.includes('codescan.io') || window.location.hostname.includes('autorabit.com');
     if (isLoggedIn(currentUser) && hasOrganizations && !pendoInitialized && isCodescan) {
       const script = document.createElement('script');
-      const orgKeys = userOrganizations.map(o => o.kee).join(',');
+      const sfAccountIds = userOrganizations.map(o => o.sfAccountId).join(',');
       const host = window.location.hostname;
 
       script.innerHTML =
@@ -62,7 +62,7 @@ export function GlobalNavUser({ currentUser, userOrganizations }: GlobalNavUserP
         "          id: '" + (currentUser.email ? currentUser.email : currentUser.login) + "'\n" +
         "        },\n" +
         "        account: {\n" +
-        "          id: '" + orgKeys + "',\n" +
+        "          id: '" + sfAccountIds + "',\n" +
         "          instance: '" + host + "'\n" +
         "        }\n" +
         "      });";

--- a/server/sonar-web/src/main/js/types/types.ts
+++ b/server/sonar-web/src/main/js/types/types.ts
@@ -884,6 +884,7 @@ export interface Organization extends OrganizationBase {
   pages?: Extension[];
   projectVisibility?: Visibility;
   notifications?: CodeScanNotification[];
+  sfAccountId?: String;
 }
 
 export interface OrganizationBase {


### PR DESCRIPTION
Recently we added an accountID column to the CodeScan cloud Organization table DB. SRO need to be able to populate this column from the Chargebee dashboard and have it show in Pendo.  

We can use the customer’s Company field on the customer in Chargebee.  This field is perfect because we can edit it easily.


In pendo, we need:

The user names (Visitor ID) in Pendo should be the email address of the user.

The AccountID in pendo should be the AccountID (customer’s Company Field) from Chargebee.