### PR TITLE
CD-7542

### DIFF
--- a/server/sonar-web/src/main/js/helpers/doc-links.ts
+++ b/server/sonar-web/src/main/js/helpers/doc-links.ts
@@ -46,7 +46,7 @@ export enum DocLink {
   AlmSamlScimAuth = '/instance-administration/authentication/saml/scim/overview/',
   AnalysisScope = '/product-guides/codescan/report-and-analysis/analysis-scope-on-codescan-cloud',
   AuthOverview = 'https://knowledgebase.autorabit.com/codescan/docs',
-  BackgroundTasks = '/codescan/docs/background-tasks',
+  BackgroundTasks = '/product-guides/codescan/report-and-analysis/background-tasks',
   BranchAnalysis = 'codescan/docs/understanding-branches-in-codescan-cloud',
   CaYC = '/codescan/docs/',
   CFamilyBuildWrapper = 'https://knowledgebase.autorabit.com/codescan/docs',


### PR DESCRIPTION
User should be logged into CodeScan application and should be on any org.

Click on analyzed project user will navigate to project overview page.

Click on Background Tasks under Project settings user will navigate to Background Tasks page where user can see the [Learn More](https://knowledgebase.autorabit.com/codescan/docs/background-tasks) link if user click on the link it is navigating to https://knowledgebase.autorabit.com/codescan/docs/background-tasks page where Page Not found is displaying which is not expected.
The new URL should be https://knowledgebase.autorabit.com/product-guides/codescan/report-and-analysis/background-tasks