### PR TITLE
CD-8186 | Added Closed Issue Statuses to CSV Reports

### DIFF
--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseFormat.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseFormat.java
@@ -272,12 +272,12 @@ public class SearchResponseFormat {
       String res = dto.getResolution();
       if (RESOLUTION_FIXED.equals(res)) {
         issueBuilder.setIssueStatus("CLOSED (FIXED)");
-      } else {
+      }else{
         issueBuilder.setIssueStatus("CLOSED (REMOVED)");
       }
-      } else {
+    }else{
         ofNullable(dto.getIssueStatus()).map(IssueStatus::name).ifPresent(issueBuilder::setIssueStatus);
-      }
+    }
   }
 
   private static void addAdditionalFieldsToIssueBuilder(Collection<SearchAdditionalField> fields, SearchResponseData data, IssueDto dto,

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseFormat.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseFormat.java
@@ -271,9 +271,9 @@ public class SearchResponseFormat {
     if (STATUS_CLOSED.equals(dto.getStatus())) {
       String res = dto.getResolution();
       if (RESOLUTION_FIXED.equals(res)) {
-        issueBuilder.setIssueStatus("CLOSED (FIXED)");
+        issueBuilder.setIssueStatus("CLOSED");
       }else{
-        issueBuilder.setIssueStatus("CLOSED (REMOVED)");
+        issueBuilder.setIssueStatus("REMOVED");
       }
     }else{
         ofNullable(dto.getIssueStatus()).map(IssueStatus::name).ifPresent(issueBuilder::setIssueStatus);

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseFormat.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseFormat.java
@@ -63,6 +63,7 @@ import org.sonarqube.ws.Issues.Actions;
 import org.sonarqube.ws.Issues.Comments;
 import org.sonarqube.ws.Issues.Component;
 import org.sonarqube.ws.Issues.Issue;
+import org.sonarqube.ws.Issues.Issue.Builder;
 import org.sonarqube.ws.Issues.Operation;
 import org.sonarqube.ws.Issues.SearchWsResponse;
 import org.sonarqube.ws.Issues.Sort;
@@ -77,6 +78,8 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
+import static org.sonar.api.issue.Issue.RESOLUTION_FIXED;
+import static org.sonar.api.issue.Issue.STATUS_CLOSED;
 import static org.sonar.db.component.ComponentQualifiers.UNIT_TEST_FILE;
 import static org.sonar.api.rule.RuleKey.EXTERNAL_RULE_REPO_PREFIX;
 import static org.sonar.server.issue.index.IssueIndex.FACET_ASSIGNED_TO_ME;
@@ -213,7 +216,7 @@ public class SearchResponseFormat {
 
     ofNullable(emptyToNull(dto.getResolution())).ifPresent(issueBuilder::setResolution);
     issueBuilder.setStatus(dto.getStatus());
-    ofNullable(dto.getIssueStatus()).map(IssueStatus::name).ifPresent(issueBuilder::setIssueStatus);
+    setExportIssueStatus(issueBuilder, dto);
     issueBuilder.setMessage(nullToEmpty(dto.getMessage()));
     issueBuilder.addAllMessageFormattings(MessageFormattingUtils.dbMessageFormattingToWs(dto.parseMessageFormattings()));
     issueBuilder.addAllTags(dto.getTags());
@@ -262,6 +265,19 @@ public class SearchResponseFormat {
       }
       issueBuilder.setSort(wsSort);
     }
+  }
+
+  private static void setExportIssueStatus(Builder issueBuilder, IssueDto dto) {
+    if (STATUS_CLOSED.equals(dto.getStatus())) {
+      String res = dto.getResolution();
+      if (RESOLUTION_FIXED.equals(res)) {
+        issueBuilder.setIssueStatus("CLOSED (FIXED)");
+      } else {
+        issueBuilder.setIssueStatus("CLOSED (REMOVED)");
+      }
+      } else {
+        ofNullable(dto.getIssueStatus()).map(IssueStatus::name).ifPresent(issueBuilder::setIssueStatus);
+      }
   }
 
   private static void addAdditionalFieldsToIssueBuilder(Collection<SearchAdditionalField> fields, SearchResponseData data, IssueDto dto,


### PR DESCRIPTION
Currently, CSV reports do not clearly distinguish closed issue statuses such as Closed. Enhance the CSV export functionality to include these closed statuses explicitly in the Status column. The exported CSV should accurately reflect the latest lifecycle state of each issue, including closed states, ensuring consistency with what users see in the UI.

Hypothesis:
If CSV reports include detailed closed statuses (Closed), users will gain better visibility into issue resolution outcomes, enabling more accurate reporting, compliance tracking, and stakeholder communication. This will reduce manual effort in categorizing closed issues after export.

Value / Purpose:

Improves reporting accuracy and transparency.

Supports audit and compliance requirements with clear issue disposition tracking.