### PR TITLE
CD-8228 Bulk Assignment Limit – AI CodeFix Agent

### DIFF
--- a/server/sonar-web/src/main/js/apps/issues/components/BulkChangeModal.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/components/BulkChangeModal.tsx
@@ -85,6 +85,7 @@ enum InputField {
 }
 
 export const MAX_PAGE_SIZE = 500;
+export const MAX_AI_CODE_ASSISTANT_BULK_ASSIGN = 10;
 
 export class BulkChangeModal extends React.PureComponent<Props, State> {
   mounted = false;
@@ -176,6 +177,29 @@ export class BulkChangeModal extends React.PureComponent<Props, State> {
       type,
     } = this.state;
 
+    if (assignee === 'ai-code-assistant') {
+      const hasAnyAiDisabled = issues.some((issue) => issue.aiCodeFixEnabled !== true);
+      if (hasAnyAiDisabled) {
+        throwGlobalError({
+          data: {
+            message:
+              'AI Agent can only be assigned to issues where AI CodeFix is available.',
+          },
+        });
+        return;
+      }
+
+      if (issues.length > MAX_AI_CODE_ASSISTANT_BULK_ASSIGN) {
+        throwGlobalError({
+          data: {
+            message:
+                'You can assign a maximum of 10 issues to the AI Agent in a single bulk action.',
+          },
+        });
+        return;
+      }
+    }
+
     const query = pickBy(
       {
         add_tags: addTags?.join(),
@@ -197,6 +221,17 @@ export class BulkChangeModal extends React.PureComponent<Props, State> {
     bulkChangeIssues(issueKeys, query).then(
       () => {
         this.setState({ submitting: false });
+
+        if (query.assign === 'ai-code-assistant') {
+          for (const issue of issues) {
+            queueCodeFix({
+              organizationKey: issue.organization,
+              projectKey: issue.projectKey,
+              issueKey: issue.key,
+            });
+          }
+        }
+
         this.props.refreshBranchStatus();
         this.props.onDone();
       },
@@ -205,14 +240,6 @@ export class BulkChangeModal extends React.PureComponent<Props, State> {
         throwGlobalError(error);
       },
     );
-    for(const issue of issues){
-      if(query.assign === "ai-code-assistant")
-        queueCodeFix({
-          organizationKey: issue.organization,
-          projectKey: issue.projectKey,
-          issueKey: issue.key,
-        });
-    }
   };
 
   getAvailableTransitions(issues: Issue[]) {

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/AssignAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/AssignAction.java
@@ -40,6 +40,7 @@ import org.sonar.db.DbSession;
 import org.sonar.db.component.ComponentDto;
 import org.sonar.db.issue.IssueDto;
 import org.sonar.db.project.ProjectDto;
+import org.sonar.db.rule.RuleDto;
 import org.sonar.db.user.UserDto;
 import org.sonar.server.issue.IssueFieldsSetter;
 import org.sonar.server.issue.IssueFinder;
@@ -49,12 +50,15 @@ import static com.google.common.base.Strings.emptyToNull;
 import static java.lang.String.format;
 import static org.sonar.core.issue.IssueChangeContext.issueChangeContextByUserBuilder;
 import static org.sonar.server.exceptions.NotFoundException.checkFound;
+import static org.sonarqube.ws.WsUtils.checkArgument;
 import static org.sonarqube.ws.client.issue.IssuesWsParameters.ACTION_ASSIGN;
 import static org.sonarqube.ws.client.issue.IssuesWsParameters.PARAM_ASSIGNEE;
 import static org.sonarqube.ws.client.issue.IssuesWsParameters.PARAM_ISSUE;
 
 public class AssignAction implements IssuesWsAction {
+
   private static final String ASSIGN_TO_ME_VALUE = "_me";
+  public static final String AI_CODE_ASSISTANT = "ai-code-assistant";
 
   private final System2 system2;
   private final UserSession userSession;
@@ -122,7 +126,16 @@ public class AssignAction implements IssuesWsAction {
       userSession.checkEntityPermission(UserRole.ISSUE_ADMIN, projectDto);
       DefaultIssue issue = issueDto.toDefaultIssue();
       UserDto user = getUser(dbSession, login);
-      if (user != null && !user.getLogin().equals("ai-code-assistant") && !hasProjectPermission(dbSession, user.getUuid(), issueDto.getProjectUuid())) {
+      if (AI_CODE_ASSISTANT.equals(login)) {
+        RuleDto ruleDto = dbClient.ruleDao().selectByKey(dbSession, issue.ruleKey())
+                .orElseThrow(() -> new IllegalStateException(
+                        format("Rule with key %s not found for issue %s", issue.ruleKey(), issueKey)));
+
+        checkArgument(
+                ruleDto.getAiCodeFixEnabled(),
+                "AI Agent can only be assigned to issues where AI CodeFix is available.");
+      }
+      if (user != null && !user.getLogin().equals(AI_CODE_ASSISTANT) && !hasProjectPermission(dbSession, user.getUuid(), issueDto.getProjectUuid())) {
         throw new IllegalArgumentException(
                 format("User '%s' does not have permission to be assigned issues in project '%s'", user.getLogin(),
                         projectDto.getKey()));

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/BulkChangeAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/BulkChangeAction.java
@@ -263,7 +263,19 @@ public class BulkChangeAction implements IssuesWsAction {
             && request.getParam("assign").isPresent()
             ? request.getParam("assign").getValue()
             : null;
+    if ("ai-code-assistant".equals(assigneeLogin)) {
+      checkArgument(
+              bulkChangeData.issues.size() <= 10,
+              "You can assign a maximum of 10 issues to the AI Agent in a single bulk action.");
 
+      boolean hasAnyRuleWithoutAiCodeFix = bulkChangeData.issues.stream()
+              .map(issue -> bulkChangeData.rulesByKey.get(issue.ruleKey()))
+              .anyMatch(rule -> rule == null || !rule.getAiCodeFixEnabled());
+
+      checkArgument(
+              !hasAnyRuleWithoutAiCodeFix,
+              "AI Agent can only be assigned to issues where AI CodeFix is available.");
+    }
     UserDto assigneeUser = null;
     if (assigneeLogin != null && !assigneeLogin.isEmpty()) {
       assigneeUser = dbClient.userDao()


### PR DESCRIPTION
Implement a system-level restriction to allow a maximum of 10 issues per bulk assignment to the AI CodeFix Agent in a single action. This limit is enforced internally to control queue load, processing stability, and AI consumption spikes.

The system should:

Allow a maximum of 10 issues per bulk assignment action

Prevent selection of more than 10 issues at once

Show a validation message if the limit is exceeded

Clearly communicate the limit in the UI (e.g., tooltip or helper text)

Validation Message Example:

“You can assign a maximum of 10 issues to the AI Agent in a single bulk action.”

Note: We will update exact number after Billing logic confirmation.