### PR TITLE
[CD-8324] | remove validation for the description of custom rules

### DIFF
--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/rule/ws/UpdateAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/rule/ws/UpdateAction.java
@@ -205,9 +205,6 @@ public class UpdateAction implements RulesWsAction {
     }
     String description = request.param(PARAM_DESCRIPTION);
     if (description != null) {
-      if (!UrlValidatorUtil.textContainsValidUrl(description)) {
-        throw BadRequestException.create(INVALID_URL);
-      }
       update.setMarkdownDescription(description);
     }
     String severity = request.param(PARAM_SEVERITY);


### PR DESCRIPTION
During analysis, we identified that rule creation and rule update follow different API endpoint flows, and each flow applies different validation logic for the rule description field. Because of this inconsistency, the same description text is accepted during rule creation but rejected during rule update.

Currently, custom rule creation goes through a separate API flow that does not enforce validation on the fields, allowing rules to be created with all parameters, including descriptions containing HTTP protocols.

However, when updating a custom rule, the request goes through a different API flow that includes validation on the description field. This validation rejects descriptions that contain HTTP protocols, causing updates to fail even if the description was originally accepted during creation.

As discussed with product team, To maintain consistency between creation and update operations, the description validation in the update flow should be removed, allowing users to update rules with any valid description, including those containing HTTP protocols.
