### PR TITLE
CD-8369 | Sorted the Parameters

### DIFF
--- a/server/sonar-web/src/main/js/api/quality-profiles.ts
+++ b/server/sonar-web/src/main/js/api/quality-profiles.ts
@@ -363,7 +363,7 @@ export interface ActivateRuleParameters {
 
 export function activateRule(data: ActivateRuleParameters) {
   const params =
-    data.params && map(data.params, (value, key) => `${key}=${csvEscape(value)}`).join(';');
+    data.params && Object.keys(data.params) .sort() .map((key) => `${key}=${csvEscape(data.params[key])}`).join(';');
   const impacts = data.impacts && map(data.impacts, (value, key) => `${key}=${value}`).join(';');
   return post('/api/qualityprofiles/activate_rule', {
     ...data,


### PR DESCRIPTION
While trying to activate a rule in CodeScan on the US instance, the request fails with 403 Forbidden. The same rule activation works successfully in the other two instances, so this appears to be specific to the US environment.