### PR TITLE
CD-8229 Daily AI CodeFix Execution Limit

### DIFF
--- a/server/sonar-web/src/main/js/api/ai-codefix.ts
+++ b/server/sonar-web/src/main/js/api/ai-codefix.ts
@@ -23,6 +23,7 @@ import {
   post,
   get,
 } from '../helpers/request';
+import { throwGlobalError } from '~sonar-aligned/helpers/error';
 
 export interface CodefixFixedFileResponse {
   jobId: string;
@@ -41,6 +42,15 @@ export function queueCodeFix(data: {
     issueKey: string;
 }): Promise<void> {
   return postJSONBody(`${CODEFIX_BASE}/queue`, data);
+}
+
+export function getCodefixQuota(organizationKey: string): Promise<{
+  dailyLimit: number;
+  currentUsage: number;
+}> {
+  return get(`${CODEFIX_BASE}/quota`, { organizationKey })
+    .then(parseJSON)
+    .catch(throwGlobalError);
 }
 
 /**

--- a/server/sonar-web/src/main/js/apps/issues/components/BulkChangeModal.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/components/BulkChangeModal.tsx
@@ -30,6 +30,7 @@ import {
   InputTextArea,
   LightLabel,
   Modal,
+  addGlobalErrorMessage,
 } from '~design-system';
 import { throwGlobalError } from '~sonar-aligned/helpers/error';
 import { bulkChangeIssues, searchIssueTags } from '../../../api/issues';
@@ -43,7 +44,7 @@ import AssigneeSelect from './AssigneeSelect';
 import TagsSelect from './TagsSelect';
 import { withOrganizationContext } from "../../organizations/OrganizationContext";
 import withComponentContext from '../../../app/components/componentContext/withComponentContext';
-import { queueCodeFix } from 'src/main/js/api/ai-codefix';
+import { getCodefixQuota, queueCodeFix } from '../../../api/ai-codefix';
 
 interface Props {
   organization: Organization;
@@ -223,15 +224,28 @@ export class BulkChangeModal extends React.PureComponent<Props, State> {
         this.setState({ submitting: false });
 
         if (query.assign === 'ai-code-assistant') {
-          for (const issue of issues) {
-            queueCodeFix({
-              organizationKey: issue.organization,
-              projectKey: issue.projectKey,
-              issueKey: issue.key,
-            });
-          }
+          getCodefixQuota(this.props.organization.kee).then((quota) => {
+            if (quota.currentUsage + issues.length > quota.dailyLimit) {
+              addGlobalErrorMessage(translate('aicodefix.daily_limit_exceeded'));
+              return;
+            }
+
+            for (const issue of issues) {
+              queueCodeFix({
+                organizationKey: issue.organization,
+                projectKey: issue.projectKey,
+                issueKey: issue.key,
+              });
+            }
+
+            this.props.refreshBranchStatus();
+            this.props.onDone();
+          });
+
+          return;
         }
 
+        // For non-AI-assistant assignments, runs normally
         this.props.refreshBranchStatus();
         this.props.onDone();
       },

--- a/server/sonar-web/src/main/js/components/issue/components/IssueAssign.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/IssueAssign.tsx
@@ -21,7 +21,7 @@
 import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Options, SingleValue } from 'react-select';
-import { LabelValueSelectOption, PopupZLevel, SearchSelectDropdown } from '~design-system';
+import { LabelValueSelectOption, PopupZLevel, SearchSelectDropdown, addGlobalErrorMessage } from '~design-system';
 import { getUsers } from '../../../api/users';
 import { CurrentUserContext } from '../../../app/components/current-user/CurrentUserContext';
 import { translate, translateWithParameters } from '../../../helpers/l10n';
@@ -29,7 +29,7 @@ import { Issue } from '../../../types/types';
 import { RestUser, isLoggedIn, isUserActive } from '../../../types/users';
 import Avatar from '../../ui/Avatar';
 import { isAiAssistantEnabled } from 'src/main/js/api/settings';
-import { queueCodeFix } from 'src/main/js/api/ai-codefix';
+import { getCodefixQuota, queueCodeFix } from '../../../api/ai-codefix';
 
 interface Props {
   organization: string;
@@ -158,20 +158,33 @@ export default function IssueAssignee(props: Props) {
   };
 
   const handleAssign = (userOption: SingleValue<LabelValueSelectOption<string>>) => {
-    if (userOption) {
-      props.onAssign(userOption.value);
-    }
     if (userOption?.value === 'ai-code-assistant') {
       const { key: issueKey, organization: organizationKey, projectKey } = props.issue;
-      queueCodeFix({
-        organizationKey,
-        projectKey: projectKey ?? '',
-        issueKey: issueKey ?? '',
-      }).then(() => {
-        if (issueKey) {
-          queryClient.invalidateQueries({ queryKey: ['codefix-status', issueKey] });
+
+      getCodefixQuota(organizationKey).then((quota) => {
+        if (quota.currentUsage + 1 > quota.dailyLimit) {
+          addGlobalErrorMessage(translate('aicodefix.daily_limit_exceeded'));
+          return;
         }
+
+        props.onAssign(userOption.value);
+
+        queueCodeFix({
+          organizationKey,
+          projectKey: projectKey ?? '',
+          issueKey: issueKey ?? '',
+        }).then(() => {
+          if (issueKey) {
+            queryClient.invalidateQueries({ queryKey: ['codefix-status', issueKey] });
+          }
+        });
       });
+
+      return;
+    }
+
+    if (userOption) {
+      props.onAssign(userOption.value);
     }
   };
 

--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -2004,6 +2004,12 @@ property.aicodefix.admin.promotion.subtitle=Unlock AI-generated fix suggestions
 property.aicodefix.admin.promotion.content=Enable users of all or part of the projects to generate an AI-suggested code fix for an issue using the Sonar AI CodeFix service. To get access to AI CodeFix:
 property.aicodefix.admin.promotion.contact=Contact us
 property.aicodefix.admin.promotion.checkDocumentation=Check documentation
+#------------------------------------------------------------------------------
+#
+# AI CODEFIX
+#
+#------------------------------------------------------------------------------
+aicodefix.daily_limit_exceeded=Daily AI CodeFix limit (100 fixes) has been reached. Please try again tomorrow.
 
 #------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Enforce an internal system limit of 100 AI CodeFix executions per day per organization to manage compute costs, maintain predictable AI usage, and prevent excessive automated processing within a single day.
The system should:

Enforce a hard cap of 100 AI fixes per day per organization

Track daily consumption in real time

Prevent additional fixes once the daily limit is reached

Display a clear notification when the limit is exhausted

Notification Example:

“Daily AI CodeFix limit (100 fixes) has been reached. Please try again tomorrow.”

Note: We will update exact number after Billing logic confirmation.