### PR TITLE
CD-8394 Notification banner for PR creation/failure

### DIFF
--- a/server/sonar-web/src/main/js/api/ai-codefix.ts
+++ b/server/sonar-web/src/main/js/api/ai-codefix.ts
@@ -25,10 +25,13 @@ import {
   checkStatus,
 } from '../helpers/request';
 import { throwGlobalError } from '~sonar-aligned/helpers/error';
+import { Notification } from '../types/types';
 
 export interface CodefixFixedFileResponse {
   jobId: string;
   fixedFileContent: string;
+  /** Project-scoped AI fix branch id when the project has allocated at least one sequence */
+  incrementalId?: string;
 }
 
 export interface CodefixCreatePrDraft {
@@ -77,11 +80,11 @@ export function getCodefixQuota(organizationKey: string): Promise<{
  * so it is not callable from outside with a raw token.
  */
 export function getCodefixFixedFile(issueKey: string): Promise<CodefixFixedFileResponse> {
-  return get(`${CODEFIX_BASE}/fixed-file`, { issueKey }).then(parseJSON);
+  return get(`${CODEFIX_BASE}/fixed-file`, { issueKey }).then(parseJSON).catch(throwGlobalError);;
 }
 
 export function getCodefixCreatePrDraft(jobId: string): Promise<CodefixCreatePrDraft> {
-  return get(`${CODEFIX_BASE}/create-pr-draft`, { jobId }).then(parseJSON);
+  return get(`${CODEFIX_BASE}/create-pr-draft`, { jobId }).then(parseJSON).catch(throwGlobalError);;
 }
 
 export function createCodefixPr(
@@ -99,5 +102,9 @@ export function createCodefixPr(
 }
 
 export function getCodefixStatus(issueKey: string): Promise<CodefixStatusResponse> {
-  return get(`${CODEFIX_BASE}/get-status`, { issueKey }).then(parseJSON);
+  return get(`${CODEFIX_BASE}/get-status`, { issueKey }).then(parseJSON).catch(throwGlobalError);;
+}
+
+export function getPullRequestStatus(jobId: string): Promise<Notification> {
+  return get(`${CODEFIX_BASE}/get-pr-status`, { jobId }).then(parseJSON).catch(throwGlobalError);;
 }

--- a/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
@@ -101,14 +101,18 @@ export function Sidebar(props: Readonly<Props>) {
   const { data: isStandardMode } = useStandardExperienceModeQuery();
   const [aiEnabled, setAiEnabled] = React.useState(false);
   React.useEffect(() => {
-        async function checkAiEnabled() {
-          const projectKey = props.component.key || "";
-          const enabled = await isAiAssistantEnabled(projectKey);
-          setAiEnabled(enabled);
-        }
+    async function checkAiEnabled() {
+      // Project-scoped issues: use project component key. Org/portfolio/app views: use organization key so the facet appears.
+      const settingsComponentKey =
+        component && isProject(component.qualifier)
+          ? component.key
+          : organization?.key ?? component?.key ?? '';
+      const enabled = await isAiAssistantEnabled(settingsComponentKey);
+      setAiEnabled(enabled);
+    }
 
-        checkAiEnabled();
-      }, [props.component.key]);
+    void checkAiEnabled();
+  }, [component?.key, component?.qualifier, organization?.key]);
   const renderComponentFacets = () => {
     const hasFileOrDirectory =
       !isApplication(component?.qualifier) && !isPortfolioLike(component?.qualifier);

--- a/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
@@ -102,17 +102,12 @@ export function Sidebar(props: Readonly<Props>) {
   const [aiEnabled, setAiEnabled] = React.useState(false);
   React.useEffect(() => {
     async function checkAiEnabled() {
-      // Project-scoped issues: use project component key. Org/portfolio/app views: use organization key so the facet appears.
-      const settingsComponentKey =
-        component && isProject(component.qualifier)
-          ? component.key
-          : organization?.key ?? component?.key ?? '';
-      const enabled = await isAiAssistantEnabled(settingsComponentKey);
+      const projectKey = props.component.key || "";
+      const enabled = await isAiAssistantEnabled(projectKey);
       setAiEnabled(enabled);
     }
-
-    void checkAiEnabled();
-  }, [component?.key, component?.qualifier, organization?.key]);
+    checkAiEnabled();
+  }, [props.component?.key]);
   const renderComponentFacets = () => {
     const hasFileOrDirectory =
       !isApplication(component?.qualifier) && !isPortfolioLike(component?.qualifier);

--- a/server/sonar-web/src/main/js/components/rules/CreatePullRequestButton.tsx
+++ b/server/sonar-web/src/main/js/components/rules/CreatePullRequestButton.tsx
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 import { CreatePRButton, CreatePRIcon, CreatePRText } from './FixDiffStyles';
 import { CreatePullRequestModal } from './CreatePullRequestModal';
@@ -25,14 +26,27 @@ import { CreatePullRequestModal } from './CreatePullRequestModal';
 interface CreatePullRequestButtonProps {
   jobId?: string;
   issueKey?: string;
+  pullRequestAlreadyCreated?: boolean;
 }
 
-export function CreatePullRequestButton({ jobId, issueKey }: Readonly<CreatePullRequestButtonProps>) {
+export function CreatePullRequestButton({
+  jobId,
+  issueKey,
+  pullRequestAlreadyCreated,
+}: Readonly<CreatePullRequestButtonProps>) {
+  const queryClient = useQueryClient();
   const [isActive, setIsActive] = React.useState(false);
-  const [isDisabled, setIsDisabled] = React.useState(false);
   const [modalOpen, setModalOpen] = React.useState(false);
 
-  const disabled = !jobId || !issueKey || isDisabled;
+  const handleModalClose = React.useCallback(() => {
+    setModalOpen(false);
+    if (jobId && issueKey) {
+      queryClient.invalidateQueries({ queryKey: ['codefix-get-pr-status', jobId] });
+      queryClient.invalidateQueries({ queryKey: ['codefix-fixed-file', issueKey] });
+    }
+  }, [jobId, issueKey, queryClient]);
+
+  const disabled = !jobId || !issueKey || Boolean(pullRequestAlreadyCreated);
 
   return (
     <>
@@ -40,7 +54,7 @@ export function CreatePullRequestButton({ jobId, issueKey }: Readonly<CreatePull
         type="button"
         onClick={() => setModalOpen(true)}
         disabled={disabled}
-        $active={isActive}
+        $active={isActive || Boolean(pullRequestAlreadyCreated)}
       >
         <CreatePRIcon>
           <img src="/images/pull-request-icon.svg" className="" alt="pull-request-icon" />
@@ -51,10 +65,9 @@ export function CreatePullRequestButton({ jobId, issueKey }: Readonly<CreatePull
         <CreatePullRequestModal
           issueKey={issueKey}
           jobId={jobId}
-          onClose={() => setModalOpen(false)}
+          onClose={handleModalClose}
           onSuccess={() => {
             setIsActive(true);
-            setIsDisabled(true);
           }}
         />
       )}

--- a/server/sonar-web/src/main/js/components/rules/CreatePullRequestModal.tsx
+++ b/server/sonar-web/src/main/js/components/rules/CreatePullRequestModal.tsx
@@ -35,6 +35,22 @@ import {
   type CodefixCreatePrDraft,
 } from '../../api/ai-codefix';
 import { translate } from '../../helpers/l10n';
+import { CodefixPrStatusBanner, useCodefixPrStatusQuery } from './PrStatusNotification';
+
+function parseCreatePrErrorMessage(err: unknown): Promise<string> {
+  if (!(err instanceof Response)) {
+    return Promise.resolve(translate('issues.code_fix.create_pr_modal.submit_error'));
+  }
+  return err
+    .json()
+    .then(
+      (data: { error?: string; message?: string }) =>
+        (typeof data?.error === 'string' && data.error) ||
+        (typeof data?.message === 'string' && data.message) ||
+        translate('issues.code_fix.create_pr_modal.submit_error'),
+    )
+    .catch(() => translate('issues.code_fix.create_pr_modal.submit_error'));
+}
 
 interface CreatePullRequestModalProps {
   jobId: string;
@@ -59,11 +75,13 @@ export function CreatePullRequestModal({
   const [prTitle, setPrTitle] = React.useState('');
   const [commitMessage, setCommitMessage] = React.useState('');
   const [description, setDescription] = React.useState('');
+  const [submitError, setSubmitError] = React.useState('');
 
   React.useEffect(() => {
     let cancelled = false;
     setLoadingDraft(true);
     setLoadError(false);
+    setSubmitError('');
     getCodefixCreatePrDraft(jobId)
       .then((d) => {
         if (!cancelled) {
@@ -90,6 +108,7 @@ export function CreatePullRequestModal({
   }, [jobId]);
 
   const handleSubmit = React.useCallback(() => {
+    setSubmitError('');
     setSubmitting(true);
     createCodefixPr(jobId, {
       baseBranch,
@@ -100,11 +119,12 @@ export function CreatePullRequestModal({
       .then(() => {
         queryClient.invalidateQueries({ queryKey: ['codefix-fixed-file', issueKey] });
         queryClient.invalidateQueries({ queryKey: ['codefix-status', issueKey] });
+        queryClient.invalidateQueries({ queryKey: ['codefix-get-pr-status', jobId] });
         onSuccess();
         onClose();
       })
-      .catch(() => {
-        /* error surfaced by request layer */
+      .catch((err: unknown) => {
+        void parseCreatePrErrorMessage(err).then(setSubmitError);
       })
       .finally(() => {
         setSubmitting(false);
@@ -121,7 +141,17 @@ export function CreatePullRequestModal({
     queryClient,
   ]);
 
+  // After a failed submit, clear the error when the user edits any field so they can retry.
+  React.useEffect(() => {
+    setSubmitError('');
+  }, [baseBranch, prTitle, commitMessage, description]);
+
   const canSubmit = !loadingDraft && !loadError && draft !== null && !submitting;
+  const primaryDisabled = !canSubmit || Boolean(submitError);
+
+  const prStatusQuery = useCodefixPrStatusQuery(jobId);
+  const prStatusType = prStatusQuery.data?.type.toLowerCase();
+  const prStatusMessage = prStatusQuery.data?.message;
 
   return (
     <Modal
@@ -139,6 +169,16 @@ export function CreatePullRequestModal({
           <FlagMessage variant="warning">{translate('issues.code_fix.create_pr_modal.load_error')}</FlagMessage>
         ) : (
           <div className="sw-flex sw-flex-col sw-gap-4">
+
+            {submitError && (
+              <div className="sw-flex sw-flex-col sw-gap-2">
+                <CodefixPrStatusBanner
+                  jobId={jobId}
+                  prStatusMessage={prStatusMessage}
+                  prStatusType={prStatusType}
+                />
+              </div>
+            )}
             <FormField htmlFor="codefix-pr-branch" label={translate('issues.code_fix.create_pr_modal.branch')}>
               <div className="sw-flex sw-flex-wrap sw-items-stretch sw-gap-2 sw-w-full">
                 <span
@@ -208,7 +248,7 @@ export function CreatePullRequestModal({
       }
       primaryButton={
         <Button
-          isDisabled={!canSubmit}
+          isDisabled={primaryDisabled}
           onClick={handleSubmit}
           variety={ButtonVariety.Primary}
         >

--- a/server/sonar-web/src/main/js/components/rules/FixDiffHeader.tsx
+++ b/server/sonar-web/src/main/js/components/rules/FixDiffHeader.tsx
@@ -18,27 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  ClipboardIconButton,
-  HoverLink,
-  InteractiveIcon,
-  LightLabel,
-  PencilIcon,
-} from '~design-system';
+import { ChevronRightIcon, ClipboardIconButton, HoverLink, LightLabel } from '~design-system';
 import { translate } from '../../helpers/l10n';
 import { collapsedDirFromPath, fileFromPath } from '../../helpers/path';
 import { getBranchLikeUrl } from '../../helpers/urls';
 import { BranchLike } from '../../types/branch-like';
 import { CreatePullRequestButton } from './CreatePullRequestButton';
-import {
-  BranchIcon,
-  BranchSelect,
-  BranchSelectButton,
-  BranchText,
-  FixDiffHeader as StyledFixDiffHeader,
-} from './FixDiffStyles';
+import { CodefixIncrementalBadge, FixDiffHeader as StyledFixDiffHeader } from './FixDiffStyles';
 
 interface FixDiffHeaderProps {
   filePath: string;
@@ -48,16 +34,20 @@ interface FixDiffHeaderProps {
   branchLike?: BranchLike;
   jobId?: string;
   issueKey?: string;
+  pullRequestAlreadyCreated?: boolean;
+  incrementalId?: string;
 }
 
 export function FixDiffHeader({
   filePath,
-  branchDisplayName,
+  branchDisplayName: _branchDisplayName,
   projectKey,
   projectName,
   branchLike,
   jobId,
   issueKey,
+  pullRequestAlreadyCreated,
+  incrementalId,
 }: Readonly<FixDiffHeaderProps>) {
   return (
     <StyledFixDiffHeader>
@@ -78,7 +68,21 @@ export function FixDiffHeader({
           copyLabel={translate('source_viewer.click_to_copy_filepath')}
         />
       </div>
-    <CreatePullRequestButton issueKey={issueKey} jobId={jobId} />
+      <div className="sw-flex sw-flex-shrink-0 sw-items-center sw-gap-2">
+        {incrementalId ? (
+          <CodefixIncrementalBadge
+            title={translate('issues.code_fix.incremental_id.tooltip')}
+            aria-label={`${translate('issues.code_fix.incremental_id.tooltip')}: ${incrementalId}`}
+          >
+            {incrementalId}
+          </CodefixIncrementalBadge>
+        ) : null}
+        <CreatePullRequestButton
+          issueKey={issueKey}
+          jobId={jobId}
+          pullRequestAlreadyCreated={pullRequestAlreadyCreated}
+        />
+      </div>
     </StyledFixDiffHeader>
   );
 }

--- a/server/sonar-web/src/main/js/components/rules/FixDiffStyles.tsx
+++ b/server/sonar-web/src/main/js/components/rules/FixDiffStyles.tsx
@@ -224,7 +224,7 @@ export const PrStatusNotification = styled.div`
 `;
 
 export const ErrorText = styled.div`
-  margin: 0 0.5rem 0.5rem;
+  margin-top: 0.75rem;
   max-height: 16rem;
   overflow: auto;
   border-radius: 0.25rem;

--- a/server/sonar-web/src/main/js/components/rules/FixDiffStyles.tsx
+++ b/server/sonar-web/src/main/js/components/rules/FixDiffStyles.tsx
@@ -217,3 +217,43 @@ export const CreatePRText = styled.span`
   line-height: var(--font-size-20, 20px);
 `;
 
+export const PrStatusNotification = styled.div`
+  position: relative;
+  z-index: 0;
+  padding: 0 0 10px 0;
+`;
+
+export const ErrorText = styled.div`
+  margin: 0 0.5rem 0.5rem;
+  max-height: 16rem;
+  overflow: auto;
+  border-radius: 0.25rem;
+  padding: 0.75rem;
+  white-space: pre-wrap;
+  font-family: monospace;
+  font-size: 0.875rem;
+
+  background-color: #fef3f2;
+  border: 1px #5d6cd0;
+  color: #111827;
+`;
+
+/** Inline chip for the project codefix incremental branch id (e.g. a1b200042) */
+export const CodefixIncrementalBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  max-width: 94rem;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid ${({ theme }) => themeColor('codeLineBorder')({ theme })};
+  background-color: ${({ theme }) => themeColor('backgroundSecondary')({ theme })};
+  color: var(--echoes-color-text-subdued, #637192);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  line-height: 2.0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/server/sonar-web/src/main/js/components/rules/FixDiffTab.tsx
+++ b/server/sonar-web/src/main/js/components/rules/FixDiffTab.tsx
@@ -27,12 +27,14 @@ import { translate } from '../../helpers/l10n';
 import { useRawSourceQuery } from '../../queries/sources';
 import { getBranchLikeQuery } from '../../sonar-aligned/helpers/branch-like';
 import { BranchLike } from '../../types/branch-like';
+import { IssueCodefixStatus } from '../../types/issues';
 import { Issue, SourceViewerFile } from '../../types/types';
 import { FixDiffHeader } from './FixDiffHeader';
 import { FixDiffTable } from './FixDiffTable';
 import { DiffSourceLine } from './FixDiffTypes';
 import { UseFixDiffSnippetRange } from './UseFixDiffSnippetRange';
 import { UseFixDiffSourceLines } from './UseFixDiffSourceLines';
+import { CodefixPrStatusBanner, useCodefixPrStatusQuery } from './PrStatusNotification';
 
 interface FixDiffTabProps {
   branchLike?: BranchLike;
@@ -63,6 +65,14 @@ export function FixDiffTab({ branchLike, issue }: Readonly<FixDiffTabProps>) {
   const fixedFileData = fixedFileQuery.data;
   const mergedSource = fixedFileData?.fixedFileContent;
   const jobId = fixedFileData?.jobId;
+  const incrementalId = fixedFileData?.incrementalId;
+
+  const prStatusQuery = useCodefixPrStatusQuery(jobId);
+  const prStatusType = prStatusQuery.data?.type.toLowerCase();
+  const prStatusMessage = prStatusQuery.data?.message;
+
+  const pullRequestAlreadyCreated =
+    prStatusType === 'success' || issue.codefixStatus === IssueCodefixStatus.PullRequestCreated;
 
   const hasChanges = React.useMemo(() => {
     if (!originalSource || !mergedSource) return false;
@@ -184,6 +194,11 @@ export function FixDiffTab({ branchLike, issue }: Readonly<FixDiffTabProps>) {
 
   return (
     <div className="sw-flex sw-flex-col sw-gap-0">
+      <CodefixPrStatusBanner
+        jobId={jobId}
+        prStatusMessage={prStatusMessage}
+        prStatusType={prStatusType}
+      />
       <FixDiffHeader
         filePath={filePath}
         branchDisplayName={branchDisplayName}
@@ -192,6 +207,8 @@ export function FixDiffTab({ branchLike, issue }: Readonly<FixDiffTabProps>) {
         branchLike={branchLike}
         issueKey={issue.key}
         jobId={jobId}
+        pullRequestAlreadyCreated={pullRequestAlreadyCreated}
+        incrementalId={incrementalId}
       />
       <FixDiffTable
         branchLike={branchLike}

--- a/server/sonar-web/src/main/js/components/rules/PrStatusNotification.tsx
+++ b/server/sonar-web/src/main/js/components/rules/PrStatusNotification.tsx
@@ -70,18 +70,25 @@ export function CodefixPrStatusBanner({
         variant={prStatusType === 'success' ? 'success' : 'error'}
       >
         {prStatusType === 'error' && prStatusMessage && (
-          <>
-            <span>{translate(`issues.code_fix.pr_status.error.text.part_one`)}</span>
-            <button
-              type="button"
-              className="sw-ml-1 sw-bg-transparent sw-border-none sw-p-0 sw-cursor-pointer sw-underline"
-              style={{ background: 'transparent', color: '#5D6CD0', marginLeft: '4px', marginRight: '4px' }}
-              onClick={() => setPrErrorDetailsOpen((open) => !open)}
-            >
-              {translate('issues.code_fix.pr_status.error.review_the_error')}
-            </button>
-            <span>{translate(`issues.code_fix.pr_status.error.text.part_two`)}</span>
-          </>
+          <div style={{ width: '100%' }}>
+            <div>
+              <span>{translate(`issues.code_fix.pr_status.error.text.part_one`)}</span>
+              <button
+                type="button"
+                className="sw-ml-1 sw-bg-transparent sw-border-none sw-p-0 sw-cursor-pointer sw-underline"
+                style={{ background: 'transparent', color: '#5D6CD0', marginLeft: '4px', marginRight: '4px' }}
+                onClick={() => setPrErrorDetailsOpen((open) => !open)}
+              >
+                {translate('issues.code_fix.pr_status.error.review_the_error')}
+              </button>
+              <span>{translate(`issues.code_fix.pr_status.error.text.part_two`)}</span>
+            </div>
+            {prErrorDetailsOpen && (
+              <ErrorText role="region" aria-label={translate('issues.code_fix.pr_status.error.details_label')}>
+                {prStatusMessage}
+              </ErrorText>
+            )}
+          </div>
         )}
 
         {prStatusType === 'success' && prStatusMessage && (
@@ -99,11 +106,6 @@ export function CodefixPrStatusBanner({
           </>
         )}
       </FlagMessage>
-      {prStatusType === 'error' && prErrorDetailsOpen && prStatusMessage && (
-        <ErrorText role="region" aria-label={translate('issues.code_fix.pr_status.error.details_label')}>
-          {prStatusMessage}
-        </ErrorText>
-      )}
     </PrStatusNotificationRoot>
   );
 }

--- a/server/sonar-web/src/main/js/components/rules/PrStatusNotification.tsx
+++ b/server/sonar-web/src/main/js/components/rules/PrStatusNotification.tsx
@@ -1,0 +1,109 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as React from 'react';
+import { FlagMessage } from '~design-system';
+import { getPullRequestStatus } from '../../api/ai-codefix';
+import { translate } from '../../helpers/l10n';
+import { ErrorText, PrStatusNotification as PrStatusNotificationRoot } from './FixDiffStyles';
+
+export function useCodefixPrStatusQuery(jobId: string | undefined) {
+  return useQuery({
+    queryKey: ['codefix-get-pr-status', jobId],
+    queryFn: () => getPullRequestStatus(jobId!),
+    enabled: Boolean(jobId),
+    retry: (_, error) => {
+      const res = error as unknown as Response;
+      return res?.status !== 401 && res?.status !== 403;
+    },
+  });
+}
+
+export interface CodefixPrStatusBannerProps {
+  /** Included so expandable error state resets when switching jobs */
+  jobId?: string;
+  prStatusType: string | undefined;
+  prStatusMessage: string | undefined;
+}
+
+/**
+ * PR outcome banner (success link or error with expandable log). Omits warning / empty states.
+ */
+export function CodefixPrStatusBanner({
+  jobId,
+  prStatusType,
+  prStatusMessage,
+}: Readonly<CodefixPrStatusBannerProps>) {
+  const [prErrorDetailsOpen, setPrErrorDetailsOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    setPrErrorDetailsOpen(false);
+  }, [jobId, prStatusType]);
+
+  if (prStatusType === undefined || prStatusType === 'warning') {
+    return null;
+  }
+
+  return (
+    <PrStatusNotificationRoot>
+      <FlagMessage
+        role="status"
+        className="sw-w-full"
+        variant={prStatusType === 'success' ? 'success' : 'error'}
+      >
+        {prStatusType === 'error' && prStatusMessage && (
+          <>
+            <span>{translate(`issues.code_fix.pr_status.error.text.part_one`)}</span>
+            <button
+              type="button"
+              className="sw-ml-1 sw-bg-transparent sw-border-none sw-p-0 sw-cursor-pointer sw-underline"
+              style={{ background: 'transparent', color: '#5D6CD0', marginLeft: '4px', marginRight: '4px' }}
+              onClick={() => setPrErrorDetailsOpen((open) => !open)}
+            >
+              {translate('issues.code_fix.pr_status.error.review_the_error')}
+            </button>
+            <span>{translate(`issues.code_fix.pr_status.error.text.part_two`)}</span>
+          </>
+        )}
+
+        {prStatusType === 'success' && prStatusMessage && (
+          <>
+            <span>{translate(`issues.code_fix.pr_status.success.text`)}</span>{' '}
+            <a
+              href={prStatusMessage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="sw-ml-1 sw-underline"
+              style={{ color: '#5D6CD0' }}
+            >
+              {translate(`issues.code_fix.pr_status.success.click_to_view`)}
+            </a>
+          </>
+        )}
+      </FlagMessage>
+      {prStatusType === 'error' && prErrorDetailsOpen && prStatusMessage && (
+        <ErrorText role="region" aria-label={translate('issues.code_fix.pr_status.error.details_label')}>
+          {prStatusMessage}
+        </ErrorText>
+      )}
+    </PrStatusNotificationRoot>
+  );
+}

--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -1221,11 +1221,19 @@ issues.code_fix.not_able_to_generate_fix= We are not able to generate a fix for 
 issues.code_fix.check_how_to_fix= Try again later, or visit the other sections above to learn how to fix this issue.
 issues.code_fix.create_pr_modal.title=Create Pull Request
 issues.code_fix.create_pr_modal.branch=Branch name
-issues.code_fix.create_pr_modal.pr_title=Pull request title
-issues.code_fix.create_pr_modal.commit_message=Commit message
-issues.code_fix.create_pr_modal.description=Pull request description
+issues.code_fix.create_pr_modal.pr_title=Pull Request Title
+issues.code_fix.create_pr_modal.commit_message=Commit Message
+issues.code_fix.create_pr_modal.description=Pull Request Description
 issues.code_fix.create_pr_modal.load_error=Could not load pull request defaults. Please try again.
-
+issues.code_fix.create_pr_modal.submit_error=Could not create the pull request. Please try again.
+issues.code_fix.create_pr_modal.try_again=Try again
+issues.code_fix.pr_status.success.text=Pull request Created Successfully.
+issues.code_fix.pr_status.success.click_to_view=Click to view
+issues.code_fix.pr_status.error.text.part_one=Pull request could not be created. Please
+issues.code_fix.pr_status.error.text.part_two=and try again.
+issues.code_fix.pr_status.error.review_the_error=review the error
+issues.code_fix.pr_status.error.details_label=Error details
+issues.code_fix.incremental_id.tooltip=Unique AI fix branch identifier for this project
 #------------------------------------------------------------------------------
 #
 # ISSUE CHANGELOG


### PR DESCRIPTION

Added Notification banner in fixed by AI tab after pr creation to show the status. 

In the case of failure status update there is expandable "review the error" button implemented

Updates in create pr form logic : after failure of pr creation, now if the form is edited the button is enabled again to try and create pr again.