### PR TITLE
CD-8503 | Fixed Tag Filter

### DIFF
--- a/server/sonar-server-common/src/main/java/org/sonar/server/rule/index/RuleIndex.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/rule/index/RuleIndex.java
@@ -534,7 +534,7 @@ public class RuleIndex {
     if (options.getFacets().contains(FACET_TAGS) || options.getFacets().contains(FACET_OLD_DEFAULT)) {
       Collection<String> tags = query.getTags();
       aggregations.put(FACET_TAGS,
-          stickyFacetBuilder.buildStickyFacet(FIELD_RULE_TAGS, FACET_TAGS, MAX_FACET_SIZE,
+          stickyFacetBuilder.buildStickyFacet(FIELD_RULE_TAGS, FACET_TAGS, FACET_MAX_SIZE,
               (tags == null) ? (new String[0]) : tags.toArray()));
     }
     if (options.getFacets().contains(FACET_TYPES)) {


### PR DESCRIPTION
On the CodeScan Rules page, if we search for a custom tag directly in the tag search bar without applying any filters, the rules do not appear, and the custom tag shows a count of 0.

To find the rules associated with the tag, we need to apply additional filters or access the rule directly for it to appear under the tag.

The expected behavior would be to show these rules immediately when searching for the tag without having to do additional filtering first.

