### PR TITLE
CD-8576 | Enable Severity Selection for Custom Security Hotspots

### DIFF
--- a/server/sonar-web/src/main/js/apps/coding-rules/components/CustomRuleFormModal.tsx
+++ b/server/sonar-web/src/main/js/apps/coding-rules/components/CustomRuleFormModal.tsx
@@ -124,7 +124,7 @@ export default function CustomRuleFormModal(props: Readonly<Props>) {
 
     const standardRule = {
       type: standardType,
-      ...(isSecurityHotspot ? {} : { severity: standardSeverity }),
+      severity: standardSeverity,
     };
 
     const cctRule = isSecurityHotspot
@@ -447,7 +447,7 @@ export default function CustomRuleFormModal(props: Readonly<Props>) {
           {isStandardMode && (
             <>
               {StandardTypeField}
-              {standardType !== 'SECURITY_HOTSPOT' && StandardSeverityField}
+              {StandardSeverityField}
             </>
           )}
           {!isStandardMode && (


### PR DESCRIPTION
Currently, in CodeScan, severity levels are visible and predefined for Security Hotspots in standard rules on the Rules page. However, when users create custom Security Hotspots, there is no option to define or assign a severity level. This creates inconsistency in rule configuration and limits users’ ability to prioritize and assess risk effectively.

To ensure consistency across standard and custom rules, users should be able to select and assign a severity level during the creation and editing of custom Security Hotspots.