### PR TITLE
CD-8714 | Insecure external named credentials

### DIFF
--- a/server/sonar-webserver-webapi/src/main/resources/cvss-metrics/ExternalCredentialPlainTextValue.json
+++ b/server/sonar-webserver-webapi/src/main/resources/cvss-metrics/ExternalCredentialPlainTextValue.json
@@ -1,0 +1,127 @@
+{
+  "ExternalCredentialPlainTextValue": {
+    "cvssScore": "9.3",
+    "baseScore": "9.9",
+    "temporalScore": "9.2",
+    "environmentalScore": "9.3",
+    "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H/E:F/RL:O/RC:C/CR:H/IR:H/AR:M/MAV:N/MAC:L/MPR:L/MUI:N/MS:C/MC:H/MI:H/MA:H",
+    "metrics": {
+      "BASE": [
+        {
+          "name": "ATTACK_VECTOR",
+          "value": "Network (N)",
+          "justification": "External Credential metadata files are typically stored in source repositories that can be accessed remotely."
+        },
+        {
+          "name": "ATTACK_COMPLEXITY",
+          "value": "Low (L)",
+          "justification": "Plain text credential values can be read directly once the metadata file is accessible."
+        },
+        {
+          "name": "PRIVILEGES_REQUIRED",
+          "value": "Low (L)",
+          "justification": "Exploitation requires access to the source repository, build artifact, or metadata files."
+        },
+        {
+          "name": "USER_INTERACTION",
+          "value": "None (N)",
+          "justification": "No user interaction is required to read exposed static credential values."
+        },
+        {
+          "name": "SCOPE",
+          "value": "Changed (C)",
+          "justification": "Exposed credentials can be used to affect external services or integrations outside the vulnerable source repository."
+        },
+        {
+          "name": "CONFIDENTIALITY",
+          "value": "High (H)",
+          "justification": "The rule exposes sensitive values such as API keys, client IDs, and authentication tokens in plain text."
+        },
+        {
+          "name": "INTEGRITY",
+          "value": "High (H)",
+          "justification": "Compromised credentials may allow unauthorized modification of connected systems or external integrations."
+        },
+        {
+          "name": "AVAILABILITY",
+          "value": "High (H)",
+          "justification": "Compromised credentials may be used to disrupt external services, integrations, or authenticated resources."
+        }
+      ],
+      "TEMPORAL": [
+        {
+          "name": "EXPLOIT_CODE_MATURITY",
+          "value": "Functional (F)",
+          "justification": "No complex exploit is required; exposed credential values can be directly reused if valid."
+        },
+        {
+          "name": "REMEDIATION_LEVEL",
+          "value": "Official Fix (O)",
+          "justification": "Clear remediation exists by replacing static string literals with dynamic merge field references or secure credential storage."
+        },
+        {
+          "name": "REPORT_CONFIDENCE",
+          "value": "Confirmed (C)",
+          "justification": "The issue is deterministically identified by detecting static parameterValue literals in ExternalCredential metadata files."
+        }
+      ],
+      "ENVIRONMENTAL": [
+        {
+          "name": "MODIFIED_ATTACK_VECTOR",
+          "value": "Network (N)",
+          "justification": "Repository or metadata access is commonly performed over a network."
+        },
+        {
+          "name": "MODIFIED_ATTACK_COMPLEXITY",
+          "value": "Low (L)",
+          "justification": "No special runtime condition is needed once the file is accessible."
+        },
+        {
+          "name": "MODIFIED_PRIVILEGES_REQUIRED",
+          "value": "Low (L)",
+          "justification": "Access to the repository, source artifact, or metadata file is required."
+        },
+        {
+          "name": "MODIFIED_USER_INTERACTION",
+          "value": "None (N)",
+          "justification": "No interaction from another user is required."
+        },
+        {
+          "name": "MODIFIED_SCOPE",
+          "value": "Changed (C)",
+          "justification": "The exposed credentials can impact systems beyond the source repository or Salesforce metadata file."
+        },
+        {
+          "name": "MODIFIED_CONFIDENTIALITY",
+          "value": "High (H)",
+          "justification": "Plain text secrets create a high risk of credential disclosure."
+        },
+        {
+          "name": "MODIFIED_INTEGRITY",
+          "value": "High (H)",
+          "justification": "Compromised credentials may permit unauthorized changes in connected services."
+        },
+        {
+          "name": "MODIFIED_AVAILABILITY",
+          "value": "High (H)",
+          "justification": "Credential misuse may allow disruption or denial of access to dependent services."
+        },
+        {
+          "name": "CONFIDENTIALITY_REQUIREMENT",
+          "value": "High (H)",
+          "justification": "Protecting credentials and authentication tokens is highly important."
+        },
+        {
+          "name": "INTEGRITY_REQUIREMENT",
+          "value": "High (H)",
+          "justification": "Credentials can grant write or administrative access to connected systems."
+        },
+        {
+          "name": "AVAILABILITY_REQUIREMENT",
+          "value": "Medium (M)",
+          "justification": "Availability impact is possible through service disruption, but the primary risk is credential disclosure and misuse."
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
External named credentials in Salesforce can store sensitive values such as API keys, client IDs, and auth tokens as plain text in parameterValue fields. When these files are committed to a repository, the credentials are exposed. CodeScan currently has no rule to detect this pattern. Secure credentials should reference dynamic merge fields (e.g. {!$eMPWR_Credentials.Token}) rather than containing literal values.