### PR TITLE
CD-8351 | Export Full Rule List in Scan Reports (Including When No Issues Are Found)

### DIFF
--- a/server/sonar-server-common/src/main/java/org/sonar/server/es/Sorting.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/es/Sorting.java
@@ -75,8 +75,12 @@ public class Sorting {
       FieldSortBuilder sortBuilder = SortBuilders.fieldSort(field.name);
       boolean effectiveAsc = asc != field.reverse;
       sortBuilder.order(effectiveAsc ? SortOrder.ASC : SortOrder.DESC);
-      boolean effectiveMissingLast = asc == field.missingLast;
-      sortBuilder.missing(effectiveMissingLast ? "_last" : "_first");
+      if (field.missingValue != null) {
+        sortBuilder.missing(field.missingValue);
+      } else {
+        boolean effectiveMissingLast = asc == field.missingLast;
+        sortBuilder.missing(effectiveMissingLast ? "_last" : "_first");
+      }
       return sortBuilder;
     }).toList();
   }
@@ -85,6 +89,7 @@ public class Sorting {
     private final String name;
     private boolean reverse = false;
     private boolean missingLast = false;
+    private Object missingValue = null;
 
     /**
      * Default is missing first, same order as requested
@@ -98,6 +103,11 @@ public class Sorting {
      */
     public Field missingLast() {
       missingLast = true;
+      return this;
+    }
+
+    public Field missingValue(Object value) {
+      missingValue = value;
       return this;
     }
 
@@ -120,5 +130,6 @@ public class Sorting {
     public boolean isMissingLast() {
       return missingLast;
     }
+
   }
 }

--- a/server/sonar-server-common/src/main/java/org/sonar/server/issue/SearchRequest.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/issue/SearchRequest.java
@@ -78,7 +78,7 @@ public class SearchRequest {
   private List<String> sansTop25;
   private List<String> sonarsourceSecurity;
   private List<String> cwe;
-  private String searchAfter;
+  private List<String> searchAfter;
   private String timeZone;
   private Integer owaspAsvsLevel;
   private List<String> codeVariants;
@@ -212,11 +212,11 @@ public class SearchRequest {
   }
 
   @CheckForNull
-  public String getSearchAfter() {
+  public List<String> getSearchAfter() {
     return searchAfter;
   }
 
-  public SearchRequest setSearchAfter(@Nullable String searchAfter) {
+  public SearchRequest setSearchAfter(@Nullable List<String> searchAfter) {
     this.searchAfter = searchAfter;
     return this;
   }

--- a/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigationExtensions.tsx
+++ b/server/sonar-web/src/main/js/apps/organizations/navigation/OrganizationNavigationExtensions.tsx
@@ -37,6 +37,7 @@ export default function OrganizationNavigationExtensions({ location, organizatio
     '/csvexport/csvexport',
     '/extension/developer/projects',
     '/policy-results',
+    '/extension/csvexport/export_rules_evaluation',
   ];
 
   const isActiveRoute = SETTINGS_URLS.some((url) => {

--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueIndex.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueIndex.java
@@ -417,11 +417,11 @@ public class IssueIndex {
     this.sorting.add(IssueQuery.SORT_BY_CREATION_DATE, FIELD_ISSUE_KEY);
     this.sorting.add(IssueQuery.SORT_BY_UPDATE_DATE, FIELD_ISSUE_FUNC_UPDATED_AT);
     this.sorting.add(IssueQuery.SORT_BY_UPDATE_DATE, FIELD_ISSUE_KEY);
-    this.sorting.add(IssueQuery.SORT_BY_CLOSE_DATE, FIELD_ISSUE_FUNC_CLOSED_AT);
+    this.sorting.add(IssueQuery.SORT_BY_CLOSE_DATE, FIELD_ISSUE_FUNC_CLOSED_AT).missingValue(0L);
     this.sorting.add(IssueQuery.SORT_BY_CLOSE_DATE, FIELD_ISSUE_KEY);
     this.sorting.add(IssueQuery.SORT_BY_FILE_LINE, FIELD_ISSUE_PROJECT_UUID);
     this.sorting.add(IssueQuery.SORT_BY_FILE_LINE, FIELD_ISSUE_FILE_PATH);
-    this.sorting.add(IssueQuery.SORT_BY_FILE_LINE, FIELD_ISSUE_LINE);
+    this.sorting.add(IssueQuery.SORT_BY_FILE_LINE, FIELD_ISSUE_LINE).missingValue(0);
     this.sorting.add(IssueQuery.SORT_BY_FILE_LINE, FIELD_ISSUE_SEVERITY_VALUE).reverse();
     this.sorting.add(IssueQuery.SORT_BY_FILE_LINE, FIELD_ISSUE_KEY);
     this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_VULNERABILITY_PROBABILITY).reverse();
@@ -429,12 +429,12 @@ public class IssueIndex {
     this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_RULE_UUID);
     this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_PROJECT_UUID);
     this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_FILE_PATH);
-    this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_LINE);
+    this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_LINE).missingValue(0);
     this.sorting.add(IssueQuery.SORT_HOTSPOTS, FIELD_ISSUE_KEY);
 
     // by default order by project, line , severity and issue key (in order to be deterministic when same ms)
     this.sorting.addDefault(FIELD_ISSUE_PROJECT_UUID);
-    this.sorting.addDefault(FIELD_ISSUE_LINE);
+    this.sorting.addDefault(FIELD_ISSUE_LINE).missingValue(0);
     this.sorting.addDefault(FIELD_ISSUE_SEVERITY_VALUE).reverse();
     this.sorting.addDefault(FIELD_ISSUE_KEY);
   }
@@ -443,10 +443,9 @@ public class IssueIndex {
     SearchRequest requestBuilder = EsClient.prepareSearch(TYPE_ISSUE.getMainType());
 
     SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-    // Adding search_after parameter  to retrieve the next page of hits using a set of sort values from the previous page.
-    if (StringUtils.isNotEmpty(query.searchAfter())) {
-      Object[] searchAfterValues = Arrays.stream(query.searchAfter().split(",")).map(String::trim).toArray();
-      sourceBuilder.searchAfter(searchAfterValues);
+    // Use the last hit sort values from the previous page to continue after 10,000 results.
+    if (!query.searchAfter().isEmpty()) {
+      sourceBuilder.searchAfter(query.searchAfter().toArray());
     }
     requestBuilder.source(sourceBuilder);
 

--- a/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQuery.java
+++ b/server/sonar-webserver-es/src/main/java/org/sonar/server/issue/index/IssueQuery.java
@@ -99,7 +99,7 @@ public class IssueQuery {
   private final String facetMode;
   private final String branchUuid;
   private final Boolean mainBranch;
-  private final String searchAfter;
+  private final List<String> searchAfter;
   private final ZoneId timeZone;
   private final Boolean newCodeOnReference;
   private final Collection<String> newCodeOnReferenceByProjectUuids;
@@ -156,7 +156,7 @@ public class IssueQuery {
     this.facetMode = builder.facetMode;
     this.branchUuid = builder.branchUuid;
     this.mainBranch = builder.mainBranch;
-    this.searchAfter = builder.searchAfter;
+    this.searchAfter = builder.searchAfter == null ? List.of() : List.copyOf(builder.searchAfter);
     this.timeZone = builder.timeZone;
     this.newCodeOnReference = builder.newCodeOnReference;
     this.newCodeOnReferenceByProjectUuids = defaultCollection(builder.newCodeOnReferenceByProjectUuids);
@@ -362,7 +362,7 @@ public class IssueQuery {
     return mainBranch;
   }
 
-  public String searchAfter() {
+  public List<String> searchAfter() {
     return searchAfter;
   }
 
@@ -451,7 +451,7 @@ public class IssueQuery {
     private String facetMode;
     private String branchUuid;
     private Boolean mainBranch = true;
-    private String searchAfter;
+    private List<String> searchAfter;
     private ZoneId timeZone;
     private Boolean newCodeOnReference = null;
     private Collection<String> newCodeOnReferenceByProjectUuids;
@@ -725,7 +725,7 @@ public class IssueQuery {
       return this;
     }
 
-    public Builder searchAfter(String searchAfter) {
+    public Builder searchAfter(@Nullable List<String> searchAfter) {
       this.searchAfter = searchAfter;
       return this;
     }

--- a/server/sonar-webserver-es/src/test/java/org/sonar/server/issue/index/IssueIndexSearchAfterTest.java
+++ b/server/sonar-webserver-es/src/test/java/org/sonar/server/issue/index/IssueIndexSearchAfterTest.java
@@ -1,0 +1,69 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.issue.index;
+
+import java.util.Arrays;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.Test;
+import org.sonar.db.component.ComponentDto;
+import org.sonar.server.es.SearchOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.db.component.ComponentTesting.newFileDto;
+import static org.sonar.db.component.ComponentTesting.newPrivateProjectDto;
+import static org.sonar.server.issue.IssueDocTesting.newDoc;
+
+class IssueIndexSearchAfterTest extends IssueIndexTestCommon {
+
+  @Test
+  void search_after_continues_after_last_hit_sort_values() {
+    ComponentDto project = newPrivateProjectDto();
+    ComponentDto file1 = newFileDto(project, null, "F1").setPath("src/main/xoo/org/sonar/samples/File.xoo");
+    ComponentDto file2 = newFileDto(project, null, "F2").setPath("src/main/xoo/org/sonar/samples/File2.xoo");
+
+    indexIssues(
+      newDoc("F1_2", project.uuid(), file1).setLine(20),
+      newDoc("F1_1", project.uuid(), file1).setLine(null),
+      newDoc("F1_3", project.uuid(), file1).setLine(25),
+      newDoc("F2_1", project.uuid(), file2).setLine(9),
+      newDoc("F2_2", project.uuid(), file2).setLine(109),
+      newDoc("F2_3", project.uuid(), file2).setLine(109));
+
+    SearchResponse firstPage = underTest.search(
+      IssueQuery.builder().sort(IssueQuery.SORT_BY_FILE_LINE).asc(true).build(),
+      new SearchOptions().setLimit(2));
+
+    assertThat(Arrays.stream(firstPage.getHits().getHits()).map(SearchHit::getId).toList())
+      .containsExactly("F1_1", "F1_2");
+    assertThat(firstPage.getHits().getHits()[0].getSortValues()).doesNotContainNull();
+
+    SearchResponse secondPage = underTest.search(
+      IssueQuery.builder()
+        .sort(IssueQuery.SORT_BY_FILE_LINE)
+        .asc(true)
+        .searchAfter(Arrays.stream(firstPage.getHits().getHits()[0].getSortValues()).map(String::valueOf).toList())
+        .build(),
+      new SearchOptions().setLimit(2));
+
+    assertThat(Arrays.stream(secondPage.getHits().getHits()).map(SearchHit::getId).toList())
+      .containsExactly("F1_2", "F1_3");
+  }
+}

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/hotspot/ws/SearchActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/hotspot/ws/SearchActionIT.java
@@ -135,6 +135,7 @@ class SearchActionIT {
   private static final String PARAM_SONARSOURCE_SECURITY = "sonarsourceSecurity";
   private static final String PARAM_CWE = "cwe";
   private static final String PARAM_FILES = "files";
+  private static final String PARAM_SEARCH_AFTER = "searchAfter";
 
   private static final Random RANDOM = new Random();
   private static final int ONE_MINUTE = 60_000;
@@ -174,6 +175,7 @@ class SearchActionIT {
     WebService.Param sansTop25Param = actionTester.getDef().param(PARAM_SANS_TOP_25);
     WebService.Param sonarsourceSecurityParam = actionTester.getDef().param(PARAM_SONARSOURCE_SECURITY);
     WebService.Param filesParam = actionTester.getDef().param(PARAM_FILES);
+    WebService.Param searchAfterParam = actionTester.getDef().param(PARAM_SEARCH_AFTER);
 
     assertThat(actionTester.getDef().isInternal()).isFalse();
     assertThat(onlyMineParam).isNotNull();
@@ -198,6 +200,8 @@ class SearchActionIT {
     assertThat(sonarsourceSecurityParam).isNotNull();
     assertThat(sonarsourceSecurityParam.isRequired()).isFalse();
     assertThat(filesParam).isNotNull();
+    assertThat(searchAfterParam).isNotNull();
+    assertThat(searchAfterParam.isRequired()).isFalse();
   }
 
   @Test
@@ -1381,6 +1385,40 @@ class SearchActionIT {
     int pageSize = 1 + new Random().nextInt(100);
 
     verifyPaging(project, file, rule, total, pageSize);
+  }
+
+  @Test
+  void search_after_returns_next_hotspot_and_bypasses_standard_10000_limit() {
+    ProjectData projectData = dbTester.components().insertPublicProject();
+    ComponentDto project = projectData.getMainBranchComponent();
+
+    userSessionRule.registerProjects(projectData.getProjectDto());
+    indexPermissions();
+    ComponentDto file = dbTester.components().insertComponent(newFileDto(project));
+    RuleDto rule = newRule(SECURITY_HOTSPOT);
+    List<IssueDto> hotspots = IntStream.rangeClosed(1, 3)
+      .mapToObj(i -> dbTester.issues().insertHotspot(rule, project, file, t -> t.setLine(i).setKee("hotspot_" + i)))
+      .collect(toList());
+    indexIssues();
+
+    SearchWsResponse firstPage = newRequest(project)
+      .setParam("ps", "1")
+      .executeProtobuf(SearchWsResponse.class);
+
+    assertThat(firstPage.getHotspotsList()).hasSize(1);
+    assertThat(firstPage.getHotspots(0).getKey()).isEqualTo(hotspots.get(0).getKey());
+    assertThat(firstPage.getHotspots(0).getSort().getSortList()).isNotEmpty();
+
+    SearchWsResponse secondPage = newRequest(project)
+      .setParam("p", "10001")
+      .setParam("ps", "1")
+      .setMultiParam(PARAM_SEARCH_AFTER, firstPage.getHotspots(0).getSort().getSortList())
+      .executeProtobuf(SearchWsResponse.class);
+
+    assertThat(secondPage.getHotspotsList()).hasSize(1);
+    assertThat(secondPage.getHotspots(0).getKey()).isEqualTo(hotspots.get(1).getKey());
+    assertThat(secondPage.getPaging().getPageIndex()).isEqualTo(10001);
+    assertThat(secondPage.getPaging().getPageSize()).isOne();
   }
 
   private void verifyPaging(ComponentDto project, ComponentDto file, RuleDto rule, int total, int pageSize) {

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/hotspot/ws/HotspotWsResponseFormatter.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/hotspot/ws/HotspotWsResponseFormatter.java
@@ -127,9 +127,25 @@ public class HotspotWsResponseFormatter {
       completeHotspotLocations(hotspot, builder, searchResponseData);
       ofNullable(hotspot.getCveId()).ifPresent(builder::setCveId);
       builder.addAllComments(createIssueComments(searchResponseData, hotspot));
+      addSort(hotspot, builder, searchResponseData);
       hotspotsList.add(builder.build());
     }
     return hotspotsList;
+  }
+
+  private static void addSort(IssueDto hotspot, Hotspots.SearchWsResponse.Hotspot.Builder builder, SearchResponseData searchResponseData) {
+    Object[] sortValues = searchResponseData.getSortValues(hotspot.getKey());
+    if (sortValues == null || sortValues.length == 0) {
+      return;
+    }
+
+    Hotspots.Sort.Builder sortBuilder = Hotspots.Sort.newBuilder();
+    for (Object sortValue : sortValues) {
+      if (sortValue != null) {
+        sortBuilder.addSort(sortValue.toString());
+      }
+    }
+    builder.setSort(sortBuilder);
   }
 
   private List<Comment> createIssueComments(SearchResponseData data, IssueDto dto) {
@@ -190,10 +206,16 @@ public class HotspotWsResponseFormatter {
     private final Set<String> updatableComments = new HashSet<>();
     private final Map<String, UserDto> usersByUuid = new HashMap<>();
     private final Map<String, String> statusMarkedByByIssueKey = new HashMap<>();
+    private final Map<String, Object[]> sortValuesByHotspotKey;
 
-    SearchResponseData(Paging paging, List<IssueDto> hotspots) {
+    SearchResponseData(Paging paging, List<IssueDto> hotspots, Map<String, Object[]> sortValuesByHotspotKey) {
       this.paging = paging;
       this.hotspots = hotspots;
+      this.sortValuesByHotspotKey = sortValuesByHotspotKey;
+    }
+
+    SearchResponseData(Paging paging, List<IssueDto> hotspots) {
+      this(paging, hotspots, Map.of());
     }
 
     boolean isPresent() {
@@ -230,6 +252,11 @@ public class HotspotWsResponseFormatter {
 
     public Map<String, ComponentDto> getComponentsByUuid() {
       return componentsByUuid;
+    }
+
+    @CheckForNull
+    Object[] getSortValues(String hotspotKey) {
+      return sortValuesByHotspotKey.get(hotspotKey);
     }
     public List<UserDto> getUsers() {
       return new ArrayList<>(usersByUuid.values());

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/hotspot/ws/SearchAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/hotspot/ws/SearchAction.java
@@ -134,6 +134,7 @@ public class SearchAction implements HotspotsWsAction {
   private static final String PARAM_CWE = "cwe";
   private static final String PARAM_FILES = "files";
   private static final String PARAM_CVSS = "cvss";
+  private static final String PARAM_SEARCH_AFTER = "searchAfter";
 
 
   private static final List<String> STATUSES = List.of(STATUS_TO_REVIEW, STATUS_REVIEWED);
@@ -175,13 +176,15 @@ public class SearchAction implements HotspotsWsAction {
     Set<String> cwes = setFromList(request.paramAsStrings(PARAM_CWE));
     Set<String> files = setFromList(request.paramAsStrings(PARAM_FILES));
     Set<String> cvsss = setFromList(request.paramAsStrings(PARAM_CVSS));
+    List<String> searchAfter = readSearchAfter(request);
 
 
     return new WsRequest(
       request.mandatoryParamAsInt(PAGE), request.mandatoryParamAsInt(PAGE_SIZE), request.param(PARAM_PROJECT), request.param(PARAM_BRANCH),
       request.param(PARAM_PULL_REQUEST), hotspotKeys, request.param(PARAM_STATUS), request.paramAsStrings(PARAM_RESOLUTION),
       request.paramAsBoolean(PARAM_IN_NEW_CODE_PERIOD), request.paramAsBoolean(PARAM_ONLY_MINE), request.paramAsInt(PARAM_OWASP_ASVS_LEVEL),
-      pciDss32, pciDss40, owaspAsvs40, owasp2017Top10, owasp2021Top10, stigAsdV5R3, casa, sansTop25, sonarsourceSecurity, cwes, files, cvsss);
+      pciDss32, pciDss40, owaspAsvs40, owasp2017Top10, owasp2021Top10, stigAsdV5R3, casa, sansTop25, sonarsourceSecurity, cwes, files, cvsss,
+      searchAfter);
   }
 
   @Override
@@ -340,6 +343,11 @@ public class SearchAction implements HotspotsWsAction {
       .setDescription("Comma-separated list of files. Returns only hotspots found in those files")
       .setExampleValue("src/main/java/org/sonar/server/Test.java")
       .setSince("9.0");
+    action.createParam(PARAM_SEARCH_AFTER)
+      .setDescription("By default, you cannot get more than 10,000 items by using from/size parameters.<br>" +
+        "If you need to page through more than 10,000 items, use the searchAfter parameter instead.<br>" +
+        "To retrieve the next page of results, repeat the request and repeat the '" + PARAM_SEARCH_AFTER + "' parameter once per sort value " +
+        "returned in the last hotspot.");
 
     action.setResponseExample(getClass().getResource("search-example.json"));
   }
@@ -423,11 +431,13 @@ public class SearchAction implements HotspotsWsAction {
     List<String> issueKeys = Arrays.stream(result.getHits().getHits())
       .map(SearchHit::getId)
       .toList();
+    Map<String, Object[]> sortValuesByHotspotKey = Arrays.stream(result.getHits().getHits())
+      .collect(Collectors.toMap(SearchHit::getId, SearchHit::getSortValues));
     collector.setIssueKeys(issueKeys);
     List<IssueDto> hotspots = toIssueDtos(dbSession, issueKeys);
 
     Paging paging = forPageIndex(wsRequest.getPage()).withPageSize(wsRequest.getIndex()).andTotal((int) getTotalHits(result).value);
-    return new SearchResponseData(paging, hotspots);
+    return new SearchResponseData(paging, hotspots, sortValuesByHotspotKey);
   }
 
   private static TotalHits getTotalHits(SearchResponse response) {
@@ -490,11 +500,20 @@ public class SearchAction implements HotspotsWsAction {
     wsRequest.getStatus().ifPresent(status -> builder.resolved(STATUS_REVIEWED.equals(status)));
     wsRequest.getResolution().ifPresent(builder::resolutions);
     addSecurityStandardFilters(wsRequest, builder);
+    builder.searchAfter(wsRequest.getSearchAfter());
 
     IssueQuery query = builder.build();
-    SearchOptions searchOptions = new SearchOptions()
-      .setPage(wsRequest.page, wsRequest.index);
+    SearchOptions searchOptions = new SearchOptions();
+    applyPaging(wsRequest, searchOptions);
     return issueIndex.search(query, searchOptions);
+  }
+
+  private static void applyPaging(WsRequest wsRequest, SearchOptions searchOptions) {
+    if (!wsRequest.getSearchAfter().isEmpty()) {
+      searchOptions.setLimit(wsRequest.getIndex());
+      return;
+    }
+    searchOptions.setPage(wsRequest.page, wsRequest.index);
   }
 
   private void validateParameters(WsRequest wsRequest) {
@@ -798,13 +817,14 @@ public class SearchAction implements HotspotsWsAction {
     private final Set<String> cwe;
     private final Set<String> cvss;
     private final Set<String> files;
+    private final List<String> searchAfter;
 
     private WsRequest(int page, int index,
       @Nullable String projectKey, @Nullable String branch, @Nullable String pullRequest, Set<String> hotspotKeys,
       @Nullable String status, @Nullable List<String> resolution, @Nullable Boolean inNewCodePeriod, @Nullable Boolean onlyMine,
       @Nullable Integer owaspAsvsLevel, Set<String> pciDss32, Set<String> pciDss40, Set<String> owaspAsvs40,
       Set<String> owaspTop10For2017, Set<String> owaspTop10For2021, Set<String> stigAsdV5R3, Set<String> casa, Set<String> sansTop25, Set<String> sonarsourceSecurity,
-      Set<String> cwe, @Nullable Set<String> files, Set<String> cvss) {
+      Set<String> cwe, @Nullable Set<String> files, Set<String> cvss, List<String> searchAfter) {
       this.page = page;
       this.index = index;
       this.projectKey = projectKey;
@@ -828,6 +848,7 @@ public class SearchAction implements HotspotsWsAction {
       this.cwe = cwe;
       this.files = files;
       this.cvss = cvss;
+      this.searchAfter = searchAfter;
     }
 
     int getPage() {
@@ -921,6 +942,10 @@ public class SearchAction implements HotspotsWsAction {
     public Set<String> getFiles() {
       return files;
     }
+
+    public List<String> getSearchAfter() {
+      return searchAfter;
+    }
   }
 
   /**
@@ -956,5 +981,16 @@ public class SearchAction implements HotspotsWsAction {
       public List<String> getIssueKeys() {
           return issueKeys;
       }
+  }
+
+  static List<String> readSearchAfter(Request request) {
+    List<String> searchAfter = request.multiParam(PARAM_SEARCH_AFTER);
+    if (searchAfter.size() == 1 && searchAfter.get(0).contains(",")) {
+      return Arrays.stream(searchAfter.get(0).split(","))
+        .map(String::trim)
+        .filter(value -> !value.isEmpty())
+        .toList();
+    }
+    return searchAfter;
   }
 }

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchAction.java
@@ -649,7 +649,11 @@ public class SearchAction implements IssuesWsAction {
 
   private SearchOptions createSearchOptionsFromRequest(SearchRequest request) {
     SearchOptions options = new SearchOptions();
-    options.setPage(request.getPage(), request.getPageSize());
+    if (request.getSearchAfter() != null && !request.getSearchAfter().isEmpty()) {
+      options.setLimit(request.getPageSize());
+    } else {
+      options.setPage(request.getPage(), request.getPageSize());
+    }
 
     List<String> facets = request.getFacets();
 
@@ -793,10 +797,21 @@ public class SearchAction implements IssuesWsAction {
             .setCvss(request.paramAsStrings(PARAM_CVSS))
             .setSonarsourceSecurity(request.paramAsStrings(PARAM_SONARSOURCE_SECURITY))
             .setTimeZone(request.param(PARAM_TIMEZONE))
-            .setSearchAfter(request.param(PARAM_SEARCH_AFTER))
+            .setSearchAfter(readSearchAfter(request))
             .setOrganization(request.param(PARAM_ORGANIZATION))
             .setCodeVariants(request.paramAsStrings(PARAM_CODE_VARIANTS))
             .setFixedInPullRequest(request.param(PARAM_FIXED_IN_PULL_REQUEST));
+  }
+
+  private static List<String> readSearchAfter(Request request) {
+    List<String> searchAfter = request.multiParam(PARAM_SEARCH_AFTER);
+    if (searchAfter.size() == 1 && searchAfter.get(0).contains(",")) {
+      return Arrays.stream(searchAfter.get(0).split(","))
+        .map(String::trim)
+        .filter(value -> !value.isEmpty())
+        .toList();
+    }
+    return searchAfter;
   }
 
   private void checkIfNeedIssueSync(DbSession dbSession, SearchRequest searchRequest) {

--- a/sonar-ws/src/main/protobuf/ws-hotspots.proto
+++ b/sonar-ws/src/main/protobuf/ws-hotspots.proto
@@ -53,7 +53,7 @@ message SearchWsResponse {
     optional string cveId = 18;
     repeated sonarqube.ws.commons.Comment comments = 19;
     optional string statusMarkedBy = 20;
-    optional Sort sort = 21;
+    optional Sort sort = 26;
   }
 }
 

--- a/sonar-ws/src/main/protobuf/ws-hotspots.proto
+++ b/sonar-ws/src/main/protobuf/ws-hotspots.proto
@@ -53,7 +53,12 @@ message SearchWsResponse {
     optional string cveId = 18;
     repeated sonarqube.ws.commons.Comment comments = 19;
     optional string statusMarkedBy = 20;
+    optional Sort sort = 21;
   }
+}
+
+message Sort {
+  repeated string sort = 1;
 }
 
 // Response of GET api/hotspots/list


### PR DESCRIPTION
Currently, when a scan completes successfully and no issues are detected, the exported CSV report appears empty because it only contains detected violations. This makes it difficult for users to verify which rules were evaluated during the scan and confirm the scope of the analysis.

To improve transparency and auditability, enhance the export functionality to allow users to view and download a report containing the full list of rules applied during the scan, even when no violations are detected and the Quality Gate passes.

The exported report should include all rules that were evaluated during the scan, along with relevant details such as rule name, rule key, category/severity, and the evaluation result (e.g., No Issues Found, Count of issues found).

This will ensure users have clear visibility into the rules executed during the scan and maintain proper documentation for compliance and audit purposes.

Hypothesis:
If the export report includes the complete list of rules evaluated during a scan, even when no violations are found, users will have better visibility and confidence in the scan results, improving auditability and compliance tracking.

Value / Purpose:

Provides transparency into which rules were executed during a scan.

Helps users validate scan coverage even when no issues are detected.