### PR TITLE
CD-8947 | Stored Issue Exception Reason with Dedicated change_type

### DIFF
--- a/server/sonar-web/src/main/js/api/issues.ts
+++ b/server/sonar-web/src/main/js/api/issues.ts
@@ -127,6 +127,8 @@ export function setIssueTransition(data: {
   issue: string;
   transition: string;
   issueResolutionExpiryDate?: string;
+  exceptionReason?: string;
+  comment?: string;
 }): Promise<IssueResponse> {
   const body: Record<string, string> = {
     issue: data.issue,
@@ -134,6 +136,13 @@ export function setIssueTransition(data: {
   };
   if (data.issueResolutionExpiryDate !== undefined) {
     body.issueResolutionExpiryDate = data.issueResolutionExpiryDate;
+  }
+  if (data.exceptionReason !== undefined) {
+    body.exceptionReason = data.exceptionReason;
+  }
+
+  if (data.comment !== undefined) {
+    body.comment = data.comment;
   }
   return postJSON('/api/issues/do_transition', body);
 }

--- a/server/sonar-web/src/main/js/apps/issues/components/BulkChangeModal.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/components/BulkChangeModal.tsx
@@ -203,11 +203,14 @@ export class BulkChangeModal extends React.PureComponent<Props, State> {
       expiryFields.issueResolutionExpiryDate = `${yyyy}-${mm}-${dd}`;
     }
 
+    const trimmedComment = comment?.trim();
+    const isExceptionTransition = transition === IssueTransition.Exception;
     const query = pickBy(
       {
         add_tags: addTags?.join(),
         assign: assignee,
-        comment,
+        exceptionReason: isExceptionTransition ? trimmedComment : undefined,
+        comment: !isExceptionTransition ? trimmedComment : undefined,
         do_transition: transition,
         remove_tags: removeTags?.join(),
         sendNotifications: notifications,

--- a/server/sonar-web/src/main/js/components/issue/components/IssueTransition.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/IssueTransition.tsx
@@ -81,6 +81,7 @@ export default function IssueTransition(props: Readonly<Props>) {
 
   async function handleSetTransition(
     transition: string,
+    exceptionReason?: string,
     comment?: string,
     issueResolutionExpiryDate?: string,
   ) {
@@ -91,11 +92,16 @@ export default function IssueTransition(props: Readonly<Props>) {
         issue: string;
         transition: string;
         issueResolutionExpiryDate?: string;
+        exceptionReason?: string;
       } = { issue: issue.key, transition };
+
+      if (transition === 'exception' && typeof exceptionReason === 'string' && exceptionReason.length > 0) {
+        transitionPayload.exceptionReason = exceptionReason;
+      }
       if (issueResolutionExpiryDate !== undefined) {
         transitionPayload.issueResolutionExpiryDate = issueResolutionExpiryDate;
       }
-      if (typeof comment === 'string' && comment.length > 0) {
+      if (typeof comment === 'string' && comment.length > 0 && transition !== 'exception') {
         await setIssueTransition(transitionPayload);
         await updateIssue(onChange, addIssueComment({ issue: issue.key, text: comment }));
       } else {

--- a/server/sonar-web/src/main/js/components/issue/components/IssueTransitionOverlay.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/IssueTransitionOverlay.tsx
@@ -52,6 +52,7 @@ export type Props = {
   onClose: () => void;
   onSetTransition: (
     transition: IssueTransition,
+    exceptionReason?: string,
     comment?: string,
     issueResolutionExpiryDate?: string,
   ) => void;
@@ -72,7 +73,7 @@ export function IssueTransitionOverlay(props: Readonly<Props>) {
 
   function selectTransition(transition: IssueTransition) {
     if (!transitionRequiresComment(transition) || !hasCommentAction) {
-      onSetTransition(transition, undefined, buildExpiryPayload(transition));
+      onSetTransition(transition, undefined, undefined, buildExpiryPayload(transition));
     } else {
       setSelectedTransition(transition);
       setExceptionExpiryDate(undefined);
@@ -99,7 +100,8 @@ export function IssueTransitionOverlay(props: Readonly<Props>) {
       }
       onSetTransition(
         selectedTransition,
-        comment,
+        selectedTransition === IssueTransition.Exception ? comment : undefined,
+        selectedTransition === IssueTransition.Exception ? undefined : comment,
         buildExpiryPayload(selectedTransition),
       );
     }

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/TransitionActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/TransitionActionIT.java
@@ -67,7 +67,7 @@ public class TransitionActionIT {
   private final DefaultIssue issue = issueDto.toDefaultIssue();
   private final MapSettings mapSettings = new MapSettings();
   private final CodeIssueExceptionExpiryService codeIssueExceptionExpiryService = new CodeIssueExceptionExpiryService(System2.INSTANCE, mapSettings.asConfig());
-  private final TransitionAction action = new TransitionAction(transitionService, codeIssueExceptionExpiryService);
+  private final TransitionAction action = new TransitionAction(transitionService, codeIssueExceptionExpiryService, updater);
 
   @Before
   public void setUp() {

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/ws/BulkChangeActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/ws/BulkChangeActionIT.java
@@ -825,7 +825,7 @@ public class BulkChangeActionIT {
     actions.add(new org.sonar.server.issue.AssignAction(db.getDbClient(), issueFieldsSetter));
     actions.add(new org.sonar.server.issue.SetSeverityAction(issueFieldsSetter, userSession));
     actions.add(new org.sonar.server.issue.SetTypeAction(issueFieldsSetter, userSession));
-    actions.add(new org.sonar.server.issue.TransitionAction(new TransitionService(userSession, issueWorkflow), codeIssueExceptionExpiryService));
+    actions.add(new org.sonar.server.issue.TransitionAction(new TransitionService(userSession, issueWorkflow), codeIssueExceptionExpiryService, issueFieldsSetter));
     actions.add(new org.sonar.server.issue.AddTagsAction(issueFieldsSetter));
     actions.add(new org.sonar.server.issue.RemoveTagsAction(issueFieldsSetter));
     actions.add(new org.sonar.server.issue.CommentAction(issueFieldsSetter));

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/ws/DoTransitionActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/ws/DoTransitionActionIT.java
@@ -113,11 +113,11 @@ public class DoTransitionActionIT {
     new WebIssueStorage(system2, dbClient, new DefaultRuleFinder(dbClient, mock(RuleDescriptionFormatter.class)), issueIndexer, new SequenceUuidFactory()),
     mock(NotificationManager.class), issueChangePostProcessor, issuesChangesSerializer);
   private ArgumentCaptor<SearchResponseData> preloadedSearchResponseDataCaptor = ArgumentCaptor.forClass(SearchResponseData.class);
-
+  private final IssueFieldsSetter issueFieldsSetter = mock(IssueFieldsSetter.class);
   private final CodeIssueExceptionExpiryService codeIssueExceptionExpiryService = new CodeIssueExceptionExpiryService(system2, mapSettings.asConfig());
 
   private WsAction underTest = new DoTransitionAction(dbClient, userSession, issueChangeEventService,
-    new IssueFinder(dbClient, userSession), issueUpdater, transitionService, responseWriter, system2, codeIssueExceptionExpiryService);
+    new IssueFinder(dbClient, userSession), issueUpdater, transitionService, responseWriter, system2, codeIssueExceptionExpiryService, issueFieldsSetter);
   private WsActionTester tester = new WsActionTester(underTest);
 
   @Before

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/TransitionAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/TransitionAction.java
@@ -30,21 +30,27 @@ import org.sonar.server.user.UserSession;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+import org.sonar.api.issue.DefaultTransitions;
 
 @ServerSide
 public class TransitionAction extends Action {
 
   public static final String DO_TRANSITION_KEY = "do_transition";
   public static final String TRANSITION_PARAMETER = "transition";
+    private static final String PARAM_EXCEPTION_REASON = "exceptionReason";
+    private static final String PARAM_COMMENT = "comment";
 
   private final TransitionService transitionService;
   private final CodeIssueExceptionExpiryService codeIssueExceptionExpiryService;
+  private final IssueFieldsSetter issueFieldsSetter;
 
-  public TransitionAction(TransitionService transitionService, CodeIssueExceptionExpiryService codeIssueExceptionExpiryService) {
+    public TransitionAction(TransitionService transitionService, CodeIssueExceptionExpiryService codeIssueExceptionExpiryService, IssueFieldsSetter issueFieldsSetter) {
     super(DO_TRANSITION_KEY);
     this.transitionService = transitionService;
     this.codeIssueExceptionExpiryService = codeIssueExceptionExpiryService;
-  }
+    this.issueFieldsSetter = issueFieldsSetter;
+    }
 
   @Override
   public boolean verify(Map<String, Object> properties, Collection<DefaultIssue> issues, UserSession userSession) {
@@ -67,6 +73,21 @@ public class TransitionAction extends Action {
     boolean hasExpiryDateParam = properties.containsKey(CodeIssueExceptionExpiryService.PARAM_ISSUE_RESOLUTION_EXPIRY_DATE);
     String expiryDateParam = (String) properties.get(CodeIssueExceptionExpiryService.PARAM_ISSUE_RESOLUTION_EXPIRY_DATE);
     codeIssueExceptionExpiryService.applyAfterTransition(issue, dtoBefore, transition, previousStatus, hasExpiryDateParam, expiryDateParam);
+    String exceptionReason = trimToNull((String) properties.get(PARAM_EXCEPTION_REASON));
+    String comment = trimToNull((String) properties.get(PARAM_COMMENT));
+    if (DefaultTransitions.EXCEPTION.equals(transition)) {
+          String reasonToSave = exceptionReason != null ? exceptionReason : comment;
+          checkArgument(reasonToSave != null,
+                  "Parameter '%s' or '%s' must be specified when transition is '%s'",
+                  PARAM_EXCEPTION_REASON, PARAM_COMMENT, DefaultTransitions.EXCEPTION);
+          issueFieldsSetter.addExceptionReason(issue, reasonToSave, context.issueChangeContext());
+          if (exceptionReason == null) {
+              comment = null;
+          }
+    }
+    if (comment != null) {
+          issueFieldsSetter.addComment(issue, comment, context.issueChangeContext());
+    }
     return true;
   }
 

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/BulkChangeAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/BulkChangeAction.java
@@ -126,6 +126,7 @@ public class BulkChangeAction implements IssuesWsAction {
 
   private static final Logger LOG = LoggerFactory.getLogger(BulkChangeAction.class);
   private static final List<String> ACTIONS_TO_DISTRIBUTE = List.of(SET_SEVERITY_KEY, SET_TYPE_KEY, DO_TRANSITION_KEY);
+  private static final String PARAM_EXCEPTION_REASON = "exceptionReason";
 
   private final System2 system2;
   private final UserSession userSession;
@@ -211,6 +212,9 @@ public class BulkChangeAction implements IssuesWsAction {
       .setSince("4.0")
       .setBooleanPossibleValues()
       .setDefaultValue("false");
+    action.createParam(PARAM_EXCEPTION_REASON)
+      .setDescription("Reason for the Exception")
+      .setRequired(false);
   }
 
   @Override
@@ -562,11 +566,30 @@ public class BulkChangeAction implements IssuesWsAction {
         transitionProps.put(TRANSITION_PARAMETER, transitionValue);
         request.getParam(PARAM_ISSUE_RESOLUTION_EXPIRY_DATE,
           v -> transitionProps.put(CodeIssueExceptionExpiryService.PARAM_ISSUE_RESOLUTION_EXPIRY_DATE, v));
+          if (DefaultTransitions.EXCEPTION.equals(transitionValue)) {
+              request.getParam(PARAM_EXCEPTION_REASON,
+                      v -> transitionProps.put(PARAM_EXCEPTION_REASON, v));
+              request.getParam(PARAM_COMMENT,
+                      v -> {
+                          if (!transitionProps.containsKey(PARAM_EXCEPTION_REASON)) {
+                              transitionProps.put(PARAM_EXCEPTION_REASON, v);
+                          }
+                      });
+          }
         properties.put(DO_TRANSITION_KEY, transitionProps);
       });
       request.getParam(PARAM_ADD_TAGS, value -> properties.put(AddTagsAction.KEY, new HashMap<>(of(TAGS_PARAMETER, value))));
       request.getParam(PARAM_REMOVE_TAGS, value -> properties.put(RemoveTagsAction.KEY, new HashMap<>(of(TAGS_PARAMETER, value))));
-      request.getParam(PARAM_COMMENT, value -> properties.put(COMMENT_KEY, new HashMap<>(of(COMMENT_PROPERTY, value))));
+        request.getParam(PARAM_COMMENT, value -> {
+            Map<String, Object> transitionProps = properties.get(DO_TRANSITION_KEY);
+
+            boolean isExceptionTransition = transitionProps != null
+                    && DefaultTransitions.EXCEPTION.equals(transitionProps.get(TRANSITION_PARAMETER));
+
+            if (!isExceptionTransition) {
+                properties.put(COMMENT_KEY, new HashMap<>(of(COMMENT_PROPERTY, value)));
+            }
+        });
       checkAtLeastOneActionIsDefined(properties.keySet());
       return properties;
     }

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/DoTransitionAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/DoTransitionAction.java
@@ -37,6 +37,7 @@ import org.sonar.db.DbSession;
 import org.sonar.db.component.BranchDto;
 import org.sonar.db.issue.IssueDto;
 import org.sonar.server.issue.CodeIssueExceptionExpiryService;
+import org.sonar.server.issue.IssueFieldsSetter;
 import org.sonar.server.issue.IssueFinder;
 import org.sonar.server.issue.TransitionService;
 import org.sonar.server.pushapi.issues.IssueChangeEventService;
@@ -52,6 +53,9 @@ import static org.sonar.db.component.BranchType.BRANCH;
 import static org.sonarqube.ws.client.issue.IssuesWsParameters.ACTION_DO_TRANSITION;
 import static org.sonarqube.ws.client.issue.IssuesWsParameters.PARAM_ISSUE;
 import static org.sonarqube.ws.client.issue.IssuesWsParameters.PARAM_TRANSITION;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+import static org.sonar.api.issue.Issue.RESOLUTION_EXCEPTION;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class DoTransitionAction implements IssuesWsAction {
 
@@ -64,10 +68,13 @@ public class DoTransitionAction implements IssuesWsAction {
   private final OperationResponseWriter responseWriter;
   private final System2 system2;
   private final CodeIssueExceptionExpiryService codeIssueExceptionExpiryService;
+  private final IssueFieldsSetter issueFieldsSetter;
+  private static final String PARAM_EXCEPTION_REASON = "exceptionReason";
+  private static final String PARAM_COMMENT = "comment";
 
   public DoTransitionAction(DbClient dbClient, UserSession userSession, IssueChangeEventService issueChangeEventService,
     IssueFinder issueFinder, IssueUpdater issueUpdater, TransitionService transitionService,
-    OperationResponseWriter responseWriter, System2 system2, CodeIssueExceptionExpiryService codeIssueExceptionExpiryService) {
+    OperationResponseWriter responseWriter, System2 system2, CodeIssueExceptionExpiryService codeIssueExceptionExpiryService, IssueFieldsSetter issueFieldsSetter) {
     this.dbClient = dbClient;
     this.userSession = userSession;
     this.issueChangeEventService = issueChangeEventService;
@@ -77,6 +84,7 @@ public class DoTransitionAction implements IssuesWsAction {
     this.responseWriter = responseWriter;
     this.system2 = system2;
     this.codeIssueExceptionExpiryService = codeIssueExceptionExpiryService;
+    this.issueFieldsSetter = issueFieldsSetter;
   }
 
   @Override
@@ -124,6 +132,12 @@ public class DoTransitionAction implements IssuesWsAction {
         + "When omitted, instance auto-expiry by severity may apply if enabled. When sent empty, expiry is cleared and auto-expiry is skipped.")
       .setExampleValue("2026-12-31")
       .setRequired(false);
+    action.createParam(PARAM_EXCEPTION_REASON)
+      .setDescription("Reason for the Exception")
+      .setRequired(false);
+    action.createParam(PARAM_COMMENT)
+      .setDescription("Optional comment text")
+      .setRequired(false);
   }
 
   @Override
@@ -146,6 +160,21 @@ public class DoTransitionAction implements IssuesWsAction {
     String expiryDateParam = request.param(CodeIssueExceptionExpiryService.PARAM_ISSUE_RESOLUTION_EXPIRY_DATE);
     if (transitionService.doTransition(defaultIssue, context, transitionKey)) {
       codeIssueExceptionExpiryService.applyAfterTransition(defaultIssue, issueDto, transitionKey, previousStatus, hasExpiryDateParam, expiryDateParam);
+      String exceptionReason = trimToNull(request.param(PARAM_EXCEPTION_REASON));
+      String comment = trimToNull(request.param(PARAM_COMMENT));
+        if (DefaultTransitions.EXCEPTION.equals(transitionKey) && RESOLUTION_EXCEPTION.equals(defaultIssue.resolution())) { // ADDED
+            if (exceptionReason == null) {
+                exceptionReason = comment;
+                comment = null;
+        }
+        checkArgument(exceptionReason != null,
+                    "Parameter '%s' or '%s' must be specified when transition is '%s'",
+                    PARAM_EXCEPTION_REASON, PARAM_COMMENT, DefaultTransitions.EXCEPTION);
+            issueFieldsSetter.addExceptionReason(defaultIssue, exceptionReason, context);
+        }
+        if (comment != null) {
+            issueFieldsSetter.addComment(defaultIssue, comment, context);
+        }
       BranchDto branch = issueUpdater.getBranch(session, defaultIssue);
       SearchResponseData response = issueUpdater.saveIssueAndPreloadSearchResponseData(session, issueDto, defaultIssue, context, branch);
 


### PR DESCRIPTION
1. Issue exception reasons are currently stored in issue_changes with change_type = comment, which makes it difficult to differentiate normal comments from exception reasons. Similar to Security Hotspots, Issues should store exception reasons separately using change_type = exception_reason.


2. Issue CSV export correctly shows:

Issue Comments
Issue Exception Reason