### PR TITLE
[CD-8840] | CodeScan Github App - Add PR creation and content write permission for AI Codefix

### DIFF
--- a/server/sonar-web/src/main/js/components/rules/CreateBulkPullRequestModal.tsx
+++ b/server/sonar-web/src/main/js/components/rules/CreateBulkPullRequestModal.tsx
@@ -43,6 +43,33 @@ interface CreateBulkPullRequestModalProps {
   onSuccess: () => void;
 }
 
+interface CreatePrError {
+  message: string;
+  ctaUrl?: string;
+}
+
+function parseCreatePrErrorMessage(err: unknown): Promise<CreatePrError> {
+  if (!(err instanceof Response)) {
+    return Promise.resolve({
+      message: translate('issues.code_fix.create_pr_modal.submit_error'),
+    });
+  }
+
+  return err
+    .json()
+    .then((data: { error?: string; message?: string; ctaUrl?: string; code?: string }) => ({
+      message:
+        data?.error ||
+        data?.message ||
+        translate('issues.code_fix.create_pr_modal.submit_error'),
+      ctaUrl: data?.ctaUrl,
+      code: data?.code,
+    }))
+    .catch(() => ({
+      message: translate('issues.code_fix.create_pr_modal.submit_error'),
+    }));
+}
+
 export function CreateBulkPullRequestModal({
   issueKeys,
   onClose,
@@ -58,6 +85,7 @@ export function CreateBulkPullRequestModal({
   const [prTitle, setPrTitle] = React.useState('');
   const [commitMessage, setCommitMessage] = React.useState('');
   const [description, setDescription] = React.useState('');
+  const [submitError, setSubmitError] = React.useState<CreatePrError | null>(null);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -111,9 +139,8 @@ export function CreateBulkPullRequestModal({
         onClose();
       })
       .catch((err: unknown) => {
-        setSubmitting(false);
-        throwGlobalError(err);
-        onClose();
+       void parseCreatePrErrorMessage(err).then(setSubmitError);
+       setSubmitting(false);
       });
   }, [
     issueKeys,
@@ -127,7 +154,7 @@ export function CreateBulkPullRequestModal({
   ]);
 
   const canSubmit = !loadingDraft && !loadError && draft !== null && !submitting;
-  const primaryDisabled = !canSubmit;
+  const primaryDisabled = !canSubmit || Boolean(submitError);
 
   return (
     <Modal
@@ -145,6 +172,24 @@ export function CreateBulkPullRequestModal({
           <FlagMessage variant="warning">{translate('issues.code_fix.create_pr_modal.load_error')}</FlagMessage>
         ) : (
           <div className="sw-flex sw-flex-col sw-gap-4">
+            {submitError && (
+                <FlagMessage variant="error">
+                  <div className="sw-flex sw-flex-col sw-gap-2">
+                    <span>{submitError.message}</span>
+
+                    {submitError.ctaUrl && (
+                      <a
+                        href={submitError.ctaUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="sw-text-blue-500 sw-underline"
+                      >
+                        Update GitHub App permissions
+                      </a>
+                    )}
+                  </div>
+                </FlagMessage>
+              )}
             <FormField htmlFor="codefix-pr-branch" label={translate('issues.code_fix.create_pr_modal.branch')}>
               <div className="sw-flex sw-flex-wrap sw-items-stretch sw-gap-2 sw-w-full">
                 <span

--- a/server/sonar-web/src/main/js/components/rules/CreatePullRequestModal.tsx
+++ b/server/sonar-web/src/main/js/components/rules/CreatePullRequestModal.tsx
@@ -37,19 +37,29 @@ import {
 import { translate } from '../../helpers/l10n';
 import { CodefixPrStatusBanner, useCodefixPrStatusQuery } from './PrStatusNotification';
 
-function parseCreatePrErrorMessage(err: unknown): Promise<string> {
+interface CreatePrError {
+  message: string;
+  ctaUrl?: string;
+}
+
+function parseCreatePrErrorMessage(err: unknown): Promise<CreatePrError> {
   if (!(err instanceof Response)) {
-    return Promise.resolve(translate('issues.code_fix.create_pr_modal.submit_error'));
-  }
-  return err
-    .json()
-    .then(
-      (data: { error?: string; message?: string }) =>
-        (typeof data?.error === 'string' && data.error) ||
-        (typeof data?.message === 'string' && data.message) ||
-        translate('issues.code_fix.create_pr_modal.submit_error'),
-    )
-    .catch(() => translate('issues.code_fix.create_pr_modal.submit_error'));
+      return Promise.resolve({
+        message: translate('issues.code_fix.create_pr_modal.submit_error'),
+      });
+    }
+    return err
+      .json()
+      .then((data: { error?: string; message?: string; ctaUrl?: string; }) => ({
+        message:
+          data?.error ||
+          data?.message ||
+          translate('issues.code_fix.create_pr_modal.submit_error'),
+        ctaUrl: data?.ctaUrl,
+      }))
+      .catch(() => ({
+        message: translate('issues.code_fix.create_pr_modal.submit_error'),
+      }));
 }
 
 interface CreatePullRequestModalProps {
@@ -75,13 +85,14 @@ export function CreatePullRequestModal({
   const [prTitle, setPrTitle] = React.useState('');
   const [commitMessage, setCommitMessage] = React.useState('');
   const [description, setDescription] = React.useState('');
-  const [submitError, setSubmitError] = React.useState('');
+//   const [submitError, setSubmitError] = React.useState('');
+  const [submitError, setSubmitError] = React.useState<CreatePrError | null>(null);
 
   React.useEffect(() => {
     let cancelled = false;
     setLoadingDraft(true);
     setLoadError(false);
-    setSubmitError('');
+    setSubmitError(null);
     getCodefixCreatePrDraft(jobId, issueKey)
       .then((d) => {
         if (!cancelled) {
@@ -108,7 +119,7 @@ export function CreatePullRequestModal({
   }, [jobId]);
 
   const handleSubmit = React.useCallback(() => {
-    setSubmitError('');
+    setSubmitError(null);
     setSubmitting(true);
     createCodefixPr(jobId, issueKey, {
       sourceBranchSuffix,
@@ -125,7 +136,6 @@ export function CreatePullRequestModal({
       })
       .catch((err: unknown) => {
         void parseCreatePrErrorMessage(err).then(setSubmitError);
-        onClose();
       })
       .finally(() => {
         setSubmitting(false);
@@ -144,7 +154,7 @@ export function CreatePullRequestModal({
 
   // After a failed submit, clear the error when the user edits any field so they can retry.
   React.useEffect(() => {
-    setSubmitError('');
+    setSubmitError(null);
   }, [sourceBranchSuffix, prTitle, commitMessage, description]);
 
   const canSubmit = !loadingDraft && !loadError && draft !== null && !submitting;
@@ -179,6 +189,25 @@ export function CreatePullRequestModal({
                   prStatusType={prStatusType}
                 />
               </div>
+            )}
+
+          {submitError && (
+              <FlagMessage variant="error">
+                <div className="sw-flex sw-flex-col sw-gap-2">
+                  <span>{submitError.message}</span>
+
+                  {submitError.ctaUrl && (
+                    <a
+                      href={submitError.ctaUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="sw-text-blue-500 sw-underline hover:sw-text-blue-600"
+                    >
+                      Update GitHub App permissions
+                    </a>
+                  )}
+                </div>
+              </FlagMessage>
             )}
             <FormField htmlFor="codefix-pr-branch" label={translate('issues.code_fix.create_pr_modal.branch')}>
               <div className="sw-flex sw-flex-wrap sw-items-stretch sw-gap-2 sw-w-full">


### PR DESCRIPTION

We need to add PR creation and content write permission to create PRs for AI Codefix, and ask customer to give those permissions.
To resolve PR creation permission issue, we need to:

Add Pull requests: Read & write permission to the GitHub App registration (add Contents: write too if not already present)

On feature entry point, call GET /app/installations/{installation_id} and check permissions.pull_requests === "write"

If permission is present → proceed with PR creation

If permission is missing → block the action and show a modal/banner with a CTA linking to https://github.com/organizations/{org}/settings/installations/{installation_id}/permissions/update (for org installs) or the user equivalent

OAuth flow: no changes — existing repo scope should already permit PR creation (need to verify); proceed directly to the create-PR API call

Add a feature flag / kill switch around the new code path so rollout can be staged and reverted without redeploy

QA: test (a) App with permission granted, (b) App pending approval, (c) App approval denied/ignored, (d) OAuth path unchanged