### PR TITLE
CD-9061 | Status Marked By Column Empty for Bulk Operations

### DIFF
--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseLoader.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchResponseLoader.java
@@ -121,7 +121,7 @@ public class SearchResponseLoader {
     Map<String, IssueChangeDto> latestByIssueKey = new HashMap<>();
     for (IssueChangeDto dto : changes) {
        String changeData = dto.getChangeData();
-       if (changeData == null || !(changeData.startsWith(FIELD_STATUS) || changeData.startsWith(FIELD_RESOLUTION ))) {
+       if (changeData == null || !(changeData.contains(FIELD_STATUS) || changeData.contains(FIELD_RESOLUTION ))) {
          continue;
        }
 


### PR DESCRIPTION
The "Status Marked By" column in the CSV Issue Export is empty when issue statuses are changed via bulk operations (api/issues/bulk_change). The column works correctly when statuses are changed via single-issue operations (api/issues/do_transition).