### PR TITLE
CD-9531 Read nested page envelope in paged codescanng responses

### DIFF
--- a/server/sonar-web/src/main/js/api/organizations.ts
+++ b/server/sonar-web/src/main/js/api/organizations.ts
@@ -161,12 +161,16 @@ export interface PendingInvitation {
   invitedOn: string;
 }
 
-export interface PageResponse<T> {
-  content: T[];
-  totalElements: number;
-  totalPages: number;
+export interface PageEnvelope {
   number: number;
   size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface PageResponse<T> {
+  content: T[];
+  page: PageEnvelope;
 }
 
 export function getPendingInvitations(data: {

--- a/server/sonar-web/src/main/js/apps/organizationMembers/PendingInvitations.tsx
+++ b/server/sonar-web/src/main/js/apps/organizationMembers/PendingInvitations.tsx
@@ -21,7 +21,7 @@ import * as React from 'react';
 import { Table } from '~design-system';
 import Avatar from '../../components/ui/Avatar';
 import ListFooter from '../../components/controls/ListFooter';
-import { getPendingInvitations, PendingInvitation } from '../../api/organizations';
+import { getPendingInvitations, PageResponse, PendingInvitation } from '../../api/organizations';
 import { Organization } from '../../types/types';
 import './MembersList.css';
 
@@ -31,6 +31,20 @@ interface Props {
 
 const PAGE_SIZE = 50;
 const AVATAR_SIZE = 36;
+
+// The backend now nests pagination metadata under `page` instead of returning it as flat fields
+// (CD-8185). Guard against a missing/malformed envelope the same way ProjectPage.js does for
+// the analysis queue response.
+function getPageData(response?: PageResponse<PendingInvitation>) {
+  if (!response || !response.page || !response.content) {
+    return undefined;
+  }
+  return {
+    items: response.content,
+    number: response.page.number ?? 0,
+    totalElements: response.page.totalElements ?? 0,
+  };
+}
 
 export default function PendingInvitations({ organization }: Props) {
   const [invitations, setInvitations] = React.useState<PendingInvitation[]>([]);
@@ -49,15 +63,15 @@ export default function PendingInvitations({ organization }: Props) {
       (response) => {
         setLoading(false);
         setLoaded(true);
-        if (!response) return;
-        const items = Array.isArray(response.content) ? response.content : [];
+        const pageData = getPageData(response);
+        if (!pageData) return;
         if (page && page > 1) {
-          setInvitations((prev) => [...prev, ...items]);
+          setInvitations((prev) => [...prev, ...pageData.items]);
         } else {
-          setInvitations(items);
+          setInvitations(pageData.items);
         }
-        setTotalElements(response.totalElements ?? 0);
-        setCurrentPage(response.number ?? 0);
+        setTotalElements(pageData.totalElements);
+        setCurrentPage(pageData.number);
       },
       () => {
         setLoading(false);

--- a/server/sonar-web/src/main/js/apps/organizationMembers/__tests__/PendingInvitations-test.tsx
+++ b/server/sonar-web/src/main/js/apps/organizationMembers/__tests__/PendingInvitations-test.tsx
@@ -1,0 +1,58 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { screen } from '@testing-library/react';
+import * as React from 'react';
+import { getPendingInvitations } from '../../../api/organizations';
+import { renderComponent } from '../../../helpers/testReactTestingUtils';
+import { Organization } from '../../../types/types';
+import PendingInvitations from '../PendingInvitations';
+
+jest.mock('../../../api/organizations');
+
+const organization: Organization = {
+  kee: 'my-org',
+  name: 'My Org',
+  inviteUsersEnabled: true,
+  actions: { admin: true },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('renders the invitations count and pagination from the nested page envelope', async () => {
+  jest.mocked(getPendingInvitations).mockResolvedValueOnce({
+    content: [
+      { id: '1', email: 'jane.doe@example.com', userType: 'STANDARD', invitedOn: '2024-01-01' },
+    ],
+    page: {
+      size: 50,
+      number: 0,
+      totalElements: 3,
+      totalPages: 1,
+    },
+  } as never);
+
+  renderComponent(<PendingInvitations organization={organization} />);
+
+  expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+  // ListFooter renders "x_of_y_shown.<count>.<total>" (translateWithParameters is mocked to join with '.')
+  expect(await screen.findByText('x_of_y_shown.1.3')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Defect

CD-8185 (Spring Boot 4 migration) changed the JSON envelope of paged `/_codescan/*` responses:

- **Before:** `{ content: [...], totalElements, totalPages, numberOfElements, number, size, first, last, empty, sort, pageable }` (flat fields)
- **After:** `{ content: [...], page: { size, number, totalElements, totalPages } }` (nested under `page`)

The flat fields are completely absent in the new shape.

## User-visible symptom

`server/sonar-web/src/main/js/apps/organizationMembers/PendingInvitations.tsx` read `response.totalElements` directly. Against the new envelope that's always `undefined`, so `totalElements` stays `0`, and the `{totalElements > 0 && (...)}` guard around the `ListFooter` never renders. Result: the pending-invitations count and pagination silently disappear from the Organization Members page, even when invitations exist.

`server/sonar-web/src/main/js/api/organizations.ts` declared `PageResponse<T>` with the old flat fields, so the type no longer matched the wire format.

## Reproduction

Added a Jest/RTL test that mocks `getPendingInvitations` returning the **new** nested shape (`{content, page: {number, totalElements, totalPages, size}}`) and asserts the invitation row and the `ListFooter` count/pagination text render. Against the pre-fix code the test failed:

```
expect(await screen.findByText('x_of_y_shown.1.3')).toBeInTheDocument();
...
Unable to find an element with the text: x_of_y_shown.1.3.
```

(`ListFooter` never mounted because `totalElements` stayed `0`.)

## Fix

- `api/organizations.ts`: replaced the flat `PageResponse<T>` fields with a `PageEnvelope` type nested under `page`, matching the new backend envelope.
- `apps/organizationMembers/PendingInvitations.tsx`: added a small `getPageData()` helper that null-safe-guards the response (`!response || !response.page || !response.content`) and reads `response.page.totalElements` / `response.page.number`, mirroring the `setQueuesData` guard pattern already used server-side in `codescanng/sonar-codescandeveloper-plugin/.../ci/ProjectPage.js` for the same envelope change.

Scanned the rest of `sonar-web` for other paged-response consumers (`grep -rn "totalElements\|totalPages\|numberOfElements"`); the only other match is `design-system/components/input/MultiSelectMenu.tsx`, which uses a local variable of the same name unrelated to any API response — left untouched.

## Test

`server/sonar-web/src/main/js/apps/organizationMembers/__tests__/PendingInvitations-test.tsx` (new) — mocks the new nested envelope and asserts the invitation renders along with the `ListFooter` count/total text. Fails against pre-fix code, passes after the fix.

```
PASS src/main/js/apps/organizationMembers/__tests__/PendingInvitations-test.tsx
  ✓ renders the invitations count and pagination from the nested page envelope

Tests:       1 passed, 1 total
```

`yarn ts-check` shows no new errors from the changed files (one pre-existing, unrelated syntax error in `api/mocks/AiCodeAssuredServiceMock.ts` exists on `origin/codescan-24.12` before this change too — confirmed by running `ts-check` on a clean checkout of the target branch).

Refs: CD-9531, CD-8185
