### PR TITLE
CD-9446 AI Code Fix Available should be Shown only for supported integrations.

### DIFF
--- a/server/sonar-web/src/main/js/api/ai-codefix.ts
+++ b/server/sonar-web/src/main/js/api/ai-codefix.ts
@@ -58,6 +58,11 @@ export interface CodefixStatusResponse {
   status: string;
 }
 
+export interface CodefixIntegrationResponse {
+  integrationType?: string;
+  supported: boolean;
+}
+
 export interface AiCreditsSummary {
   allocatedCredits: number;
   consumedCredits: number;
@@ -131,6 +136,10 @@ export function createCodefixPr(
       .then((response) => checkStatus(response, false))
       .then(() => resolve(), reject);
   });
+}
+
+export function getCodefixIntegration(projectKey: string): Promise<CodefixIntegrationResponse> {
+  return get(`${CODEFIX_BASE}/integration`, {projectKey}).then(parseJSON);
 }
 
 export function getCodefixStatus(issueKey: string): Promise<CodefixStatusResponse> {

--- a/server/sonar-web/src/main/js/apps/issues/__tests__/IssueApp-it.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/__tests__/IssueApp-it.tsx
@@ -99,6 +99,8 @@ describe('issue app', () => {
     componentsHandler.registerComponent({
       ...mockComponent({ key: 'myproject' }),
       isAiCodeFixEnabled: true,
+      // AI CodeFix is only offered on GitHub/GitLab repositories, identified by the project's ALM tag.
+      tags: ['github'],
     } as Component);
     sourcesHandler.setSource(
       range(0, 1)
@@ -173,6 +175,8 @@ describe('issue app', () => {
     componentsHandler.registerComponent({
       ...mockComponent({ key: 'myproject' }),
       isAiCodeFixEnabled: true,
+      // AI CodeFix is only offered on GitHub/GitLab repositories, identified by the project's ALM tag.
+      tags: ['github'],
     } as Component);
     const user = userEvent.setup();
     renderProjectIssuesApp(

--- a/server/sonar-web/src/main/js/apps/issues/components/AssigneeSelect.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/components/AssigneeSelect.tsx
@@ -27,12 +27,15 @@ import { isDefined } from '../../../helpers/types';
 import { Issue } from '../../../types/types';
 import { RestUser, UserActive, isLoggedIn, isUserActive } from '../../../types/users';
 import { searchAssignees } from '../utils';
-import { isAiAssistantEnabled } from 'src/main/js/api/settings';
+import { isAiAssistantEnabled } from '../../../api/settings';
+import { useAreAllAiCodefixSupportedIntegrations } from '../../../queries/ai-codefix';
 
 // exported for test
 export const MIN_QUERY_LENGTH = 2;
 
 const UNASSIGNED: Option = { value: '', label: translate('unassigned') };
+
+const AI_CODE_ASSISTANT_LOGIN = 'ai-code-assistant';
 
 interface Option extends SelectOption {
   Icon?: React.JSX.Element;
@@ -73,6 +76,13 @@ export default function AssigneeSelect(props: Readonly<AssigneeSelectProps>) {
 
     checkAiEnabled();
   }, [issues]);
+
+  const allIssuesAiCodeFixEnabled = issues.every((issue) => issue.aiCodeFixEnabled === true);
+  const mayOfferAiAssistant = aiEnabled && allIssuesAiCodeFixEnabled;
+  const allIntegrationsSupported = useAreAllAiCodefixSupportedIntegrations(
+      mayOfferAiAssistant ? issues.map((issue) => issue.project) : [],
+  );
+  const canAssignAiAssistant = mayOfferAiAssistant && allIntegrationsSupported;
   const defaultOptions = React.useMemo((): Option[] => {
     const allowCurrentUserSelection =
       isLoggedIn(currentUser) && issues.some((issue) => currentUser.login !== issue.assignee);
@@ -84,21 +94,21 @@ export default function AssigneeSelect(props: Readonly<AssigneeSelectProps>) {
 const defaultOptionsWithAi = React.useMemo((): Option[] => {
   return [
     ...defaultOptions,
-    ...(aiEnabled
+    ...(canAssignAiAssistant
       ? [
           {
-            value: "ai-code-assistant",
+            value: AI_CODE_ASSISTANT_LOGIN,
             label: "AI Code Assistant",
             Icon: <img className="ai-assistant-icon" src='/images/ai-assistant.svg' alt="AI Code Assistant" />
           }
         ]
       : [])
   ];
-}, [defaultOptions, aiEnabled]); 
+}, [defaultOptions, canAssignAiAssistant]);
 
 React.useEffect(() => {
   setOptions(undefined); // Clear search results when AI status changes
-}, [aiEnabled]);  
+}, [canAssignAiAssistant]);
 
   const handleAssigneeSearch = React.useCallback(
     async (query: string) => {
@@ -106,13 +116,15 @@ React.useEffect(() => {
         setOptions(undefined);
         return;
       }
-      const assignees = await searchAssignees(query, props.organization).then(({ results }) =>              
-        results.map(userToOption),      
+      const assignees = await searchAssignees(query, props.organization).then(({ results }) =>
+        results
+          .filter((user) => canAssignAiAssistant || user.login !== AI_CODE_ASSISTANT_LOGIN)
+          .map(userToOption),
       );
 
       setOptions(assignees);
     },
-    [props.issues[0]?.projectKey],
+    [props.issues[0]?.project, canAssignAiAssistant],
   );
 
   return (

--- a/server/sonar-web/src/main/js/apps/issues/components/__tests__/AssigneeSelect-test.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/components/__tests__/AssigneeSelect-test.tsx
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { byRole } from '~sonar-aligned/helpers/testSelector';
 import CurrentUserContextProvider from '../../../../app/components/current-user/CurrentUserContextProvider';
@@ -27,6 +27,27 @@ import { mockCurrentUser, mockIssue, mockLoggedInUser } from '../../../../helper
 import { renderComponent } from '../../../../helpers/testReactTestingUtils';
 import { CurrentUser } from '../../../../types/users';
 import AssigneeSelect, { AssigneeSelectProps, MIN_QUERY_LENGTH } from '../AssigneeSelect';
+import { getCodefixIntegration } from '../../../../api/ai-codefix';
+import { isAiAssistantEnabled } from '../../../../api/settings';
+
+const AI_CODE_ASSISTANT = 'AI Code Assistant';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: AI assistant off, so the existing suggestion tests are unaffected by the AI option.
+  jest.mocked(isAiAssistantEnabled).mockResolvedValue(false);
+  mockIntegration('webhook');
+});
+
+function mockIntegration(integrationType: string) {
+  jest.mocked(getCodefixIntegration).mockResolvedValue({
+    integrationType,
+    supported: ['github', 'gitlab'].includes(integrationType),
+  });
+}
+
+jest.mock('../../../../api/settings');
+jest.mock('../../../../api/ai-codefix');
 
 jest.mock('../../utils', () => ({
   searchAssignees: jest.fn().mockResolvedValue({
@@ -48,6 +69,8 @@ jest.mock('../../utils', () => ({
         avatar: 'avatar3',
         login: 'titi@titi',
       }),
+      // A real user row, so the gate has to filter it out of search results too.
+      mockUserBase({ active: true, login: 'ai-code-assistant', name: 'AI Code Assistant' }),
     ],
   }),
 }));
@@ -123,6 +146,83 @@ it('should handle assignee selection', async () => {
   // Select assignee when suggestion is selected
   await user.click(screen.getByLabelText('toto'));
   expect(onAssigneeSelect).toHaveBeenCalledTimes(1);
+});
+
+describe('AI Code Assistant option', () => {
+  const aiIssue = (project: string) =>
+    mockIssue(false, { assignee: 'someone', project, aiCodeFixEnabled: true });
+
+  it.each([['github'], ['gitlab']])(
+    'is offered when every issue sits on %s',
+    async (integrationType) => {
+    jest.mocked(isAiAssistantEnabled).mockResolvedValue(true);
+    mockIntegration(integrationType);
+    const user = userEvent.setup();
+    renderAssigneeSelect({ issues: [aiIssue('proj')] }, mockLoggedInUser());
+
+    await user.click(ui.combobox.get());
+    expect(await screen.findByText(AI_CODE_ASSISTANT)).toBeInTheDocument();
+    },
+  );
+
+  it.each([['metadata_api'], ['bitbucket'], ['webhook']])(
+    'is not offered when the issues sit on %s',
+    async (integrationType) => {
+    jest.mocked(isAiAssistantEnabled).mockResolvedValue(true);
+    mockIntegration(integrationType);
+    const user = userEvent.setup();
+    renderAssigneeSelect({ issues: [aiIssue('proj')] }, mockLoggedInUser());
+
+    await user.click(ui.combobox.get());
+    await waitFor(() => {
+      expect(getCodefixIntegration).toHaveBeenCalledWith('proj');
+    });
+    expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+    },
+  );
+
+  it('is not offered when a multi-project selection mixes supported and unsupported integrations', async () => {
+    jest.mocked(isAiAssistantEnabled).mockResolvedValue(true);
+    jest.mocked(getCodefixIntegration).mockImplementation((projectKey) =>
+      Promise.resolve(
+        projectKey === 'gh'
+          ? { integrationType: 'github', supported: true }
+          : { integrationType: 'metadata_api', supported: false },
+      ),
+    );
+    const user = userEvent.setup();
+    renderAssigneeSelect({ issues: [aiIssue('gh'), aiIssue('sf')] }, mockLoggedInUser());
+
+    await user.click(ui.combobox.get());
+    await waitFor(() => {
+      expect(getCodefixIntegration).toHaveBeenCalledWith('sf');
+    });
+    expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+  });
+
+  it('does not look up any project when the AI assistant is switched off', async () => {
+    jest.mocked(isAiAssistantEnabled).mockResolvedValue(false);
+    mockIntegration('github');
+    const user = userEvent.setup();
+    renderAssigneeSelect({ issues: [aiIssue('proj')] }, mockLoggedInUser());
+
+    await user.click(ui.combobox.get());
+    expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+    expect(getCodefixIntegration).not.toHaveBeenCalled();
+  });
+
+  it('keeps ai-code-assistant out of search results when the integration is unsupported', async () => {
+    jest.mocked(isAiAssistantEnabled).mockResolvedValue(true);
+    mockIntegration('metadata_api');
+    const user = userEvent.setup();
+    renderAssigneeSelect({ issues: [aiIssue('proj')] }, mockLoggedInUser());
+
+    await user.click(ui.combobox.get());
+    await user.type(ui.combobox.get(), 'assistant');
+
+    expect(await screen.findByText('toto')).toBeInTheDocument();
+    expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+  });
 });
 
 function renderAssigneeSelect(

--- a/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
@@ -101,18 +101,18 @@ export function Sidebar(props: Readonly<Props>) {
   const { settings } = useAppState();
   const { hasFeature } = useAvailableFeatures();
   const { data: isStandardMode } = useStandardExperienceModeQuery();
+  const projectKey = props.component?.key ?? "";
   const [aiEnabled, setAiEnabled] = React.useState(false);
   React.useEffect(() => {
     async function checkAiEnabled() {
-      const projectKey = props.component?.key ?? "";
       const enabled = await isAiAssistantEnabled(projectKey);
       setAiEnabled(enabled);
     }
     checkAiEnabled();
-  }, [props.component?.key]);
+  }, [projectKey]);
 
   const isSupportedIntegration = useIsAiCodefixSupportedIntegration(
-    aiEnabled ? props.component?.key : undefined,
+    aiEnabled ? projectKey : undefined,
   );
 
   const renderComponentFacets = () => {

--- a/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
+++ b/server/sonar-web/src/main/js/apps/issues/sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { BasicSeparator, FlagMessage, Link } from '~design-system';
 import { isBranch, isPullRequest } from '~sonar-aligned/helpers/branch-like';
@@ -61,7 +62,8 @@ import { StandardFacet } from './StandardFacet';
 import { TagFacet } from './TagFacet';
 import { TypeFacet } from './TypeFacet';
 import { VariantFacet } from './VariantFacet';
-import { isAiAssistantEnabled } from 'src/main/js/api/settings';
+import {isAiAssistantEnabled} from '../../../api/settings';
+import {useIsAiCodefixSupportedIntegration} from '../../../queries/ai-codefix';
 
 export interface Props {
   organization?: Organization;
@@ -102,12 +104,17 @@ export function Sidebar(props: Readonly<Props>) {
   const [aiEnabled, setAiEnabled] = React.useState(false);
   React.useEffect(() => {
     async function checkAiEnabled() {
-      const projectKey = props.component.key || "";
+      const projectKey = props.component?.key ?? "";
       const enabled = await isAiAssistantEnabled(projectKey);
       setAiEnabled(enabled);
     }
     checkAiEnabled();
   }, [props.component?.key]);
+
+  const isSupportedIntegration = useIsAiCodefixSupportedIntegration(
+    aiEnabled ? props.component?.key : undefined,
+  );
+
   const renderComponentFacets = () => {
     const hasFileOrDirectory =
       !isApplication(component?.qualifier) && !isPortfolioLike(component?.qualifier);
@@ -486,7 +493,7 @@ export function Sidebar(props: Readonly<Props>) {
                 </>
               )}
 
-              { aiEnabled && (
+              { aiEnabled && isSupportedIntegration && (
                 <>
                   <BasicSeparator className="sw-my-4" />
 

--- a/server/sonar-web/src/main/js/components/issue/components/IssueAssign.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/IssueAssign.tsx
@@ -29,14 +29,15 @@ import { translate, translateWithParameters } from '../../../helpers/l10n';
 import { Issue } from '../../../types/types';
 import { RestUser, isLoggedIn, isUserActive } from '../../../types/users';
 import Avatar from '../../ui/Avatar';
-import { isAiAssistantEnabled } from 'src/main/js/api/settings';
+import { isAiAssistantEnabled } from '../../../api/settings';
 import { getCodefixQuota, queueCodeFix } from '../../../api/ai-codefix';
+import { useIsAiCodefixSupportedIntegration } from '../../../queries/ai-codefix';
 
 interface Props {
   organization: string;
   canAssign: boolean;
   isOpen: boolean;
-  issue: Pick<Issue, 'assignee' | 'assigneeActive' | 'assigneeAvatar' | 'assigneeName' | 'assigneeLogin' | 'aiCodeFixEnabled' | 'key' | 'projectKey' | 'projectOrganization' | 'organization' | 'codefixStatus'>;
+  issue: Pick<Issue, 'assignee' | 'assigneeActive' | 'assigneeAvatar' | 'assigneeName' | 'assigneeLogin' | 'aiCodeFixEnabled' | 'key' | 'project' | 'projectKey' | 'projectOrganization' | 'organization' | 'codefixStatus'>;
   onAssign: (login: string) => void | Promise<void>;
   togglePopup: (popup: string, show?: boolean) => void;
 }
@@ -83,10 +84,19 @@ export default function IssueAssignee(props: Props) {
       }
   
       checkAiEnabled();
-    }, [props.issue.projectKey]);
+    }, [props.issue.project]);
+
+  const isSupportedIntegration = useIsAiCodefixSupportedIntegration(
+      aiEnabled ? props.issue.project : undefined,
+  );
+
+  const canAssignAiAssistant = Boolean(
+      aiEnabled && props.issue.aiCodeFixEnabled && isSupportedIntegration,
+  );
+
     const defaultOptionsWithAi = React.useMemo(() => [
       ...defaultOptions,
-      ...(aiEnabled && props.issue.aiCodeFixEnabled
+      ...(canAssignAiAssistant
         ? [
             {
               value: AI_ASSISTANT_VALUE,
@@ -101,7 +111,7 @@ export default function IssueAssignee(props: Props) {
             }
           ]
         : [])
-    ], [defaultOptions, aiEnabled]);
+    ], [defaultOptions, canAssignAiAssistant]);
 
     const isAiAssistant =
       assignee === AI_ASSISTANT_VALUE ||
@@ -138,6 +148,7 @@ export default function IssueAssignee(props: Props) {
       .then((result) => {
         const options: Array<LabelValueSelectOption<string>> = result.users
           .filter(isUserActive)
+            .filter((u) => canAssignAiAssistant || u.login !== AI_ASSISTANT_VALUE)
           .map((u) => ({
             label: u.name ?? u.login,
             value: u.login,
@@ -171,11 +182,17 @@ export default function IssueAssignee(props: Props) {
   };
 
   const handleAssign = async (userOption: SingleValue<LabelValueSelectOption<string>>) => {
-    if (userOption?.value === 'ai-code-assistant') {
+    if (userOption?.value === AI_ASSISTANT_VALUE) {
+
+      if (!canAssignAiAssistant) {
+        handleClose();
+        return;
+      }
+
       const {
         key: issueKey,
         organization: organizationKey,
-        projectKey,
+        project: projectKey,
         codefixStatus,
       } = props.issue;
 

--- a/server/sonar-web/src/main/js/components/issue/components/IssueCodefixStatusBadge.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/IssueCodefixStatusBadge.tsx
@@ -23,6 +23,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import { getCodefixStatus } from '../../../api/ai-codefix';
 import { getValues } from '../../../api/settings';
+import { useIsAiCodefixSupportedIntegration } from '../../../queries/ai-codefix';
 import { AiCodefixIconKind, AiCodefixStatusIcon } from '../../icons/AiCodefixStatusIcon';
 import { Issue } from '../../../types/types';
 
@@ -101,6 +102,8 @@ export default function AiCodefixBadge({ issue }: { issue: Issue }) {
   const hasAiFix = hasAiCodefix(issue);
   const queryClient = useQueryClient();
 
+  const isSupportedAlm = useIsAiCodefixSupportedIntegration(issue.project);
+
   // Automation mode tells us whether a FIX_GENERATED job will get a PR automatically. No staleTime, but the
   // per-project query key dedupes to ~1 settings call per project, only on mount (never polled).
   const { data: automationMode } = useQuery({
@@ -169,6 +172,9 @@ export default function AiCodefixBadge({ issue }: { issue: Issue }) {
     isAutomaticFixGenerated && prInProgressVisible ? 'PULL_REQUEST_IN_PROGRESS' : rawStatus;
 
   if (!hasAiFix || isError || !displayStatus) {
+    if (!isSupportedAlm) {
+      return null;
+    }
     return (
       <div className="sparkle-label sw-mr-5 magic-wand-text">
         <AiCodefixStatusIcon kind="available" />
@@ -178,6 +184,10 @@ export default function AiCodefixBadge({ issue }: { issue: Issue }) {
   }
 
   const { kind, text, textClassName } = getAiCodefixStatusDisplay(displayStatus);
+
+  if (kind === 'available' && !isSupportedAlm) {
+    return null;
+  }
   return (
     <div className={classNames('codefix-status-label sw-mr-5', textClassName)}>
       <AiCodefixStatusIcon kind={kind} spinning={kind === 'in-progress'} />

--- a/server/sonar-web/src/main/js/components/issue/components/__tests__/IssueAssign-test.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/__tests__/IssueAssign-test.tsx
@@ -1,0 +1,139 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import { getCodefixIntegration } from '../../../../api/ai-codefix';
+import { isAiAssistantEnabled } from '../../../../api/settings';
+import CurrentUserContextProvider from '../../../../app/components/current-user/CurrentUserContextProvider';
+import { mockIssue, mockLoggedInUser } from '../../../../helpers/testMocks';
+import { renderComponent } from '../../../../helpers/testReactTestingUtils';
+import IssueAssign from '../IssueAssign';
+
+jest.mock('../../../../api/settings');
+jest.mock('../../../../api/ai-codefix');
+jest.mock('../../../../api/users', () => ({
+  getUsers: jest.fn().mockResolvedValue({
+    users: [
+      { active: true, login: 'luke', name: 'Luke' },
+      // A real user row, so the gate has to filter it out of search results too.
+      { active: true, login: 'ai-code-assistant', name: 'AI Code Assistant' },
+    ],
+  }),
+}));
+
+const AI_CODE_ASSISTANT = 'AI Code Assistant';
+const PROJECT_KEY = 'my-project';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(isAiAssistantEnabled).mockResolvedValue(true);
+});
+
+it.each([['github'], ['gitlab']])(
+  'offers the AI Code Assistant as an assignee on a %s project',
+  async (integrationType) => {
+    renderIssueAssign(integrationType);
+
+    expect(await screen.findByText(AI_CODE_ASSISTANT)).toBeInTheDocument();
+  },
+);
+
+it.each([['metadata_api'], ['bitbucket'], ['bitbucket-enterprise'], ['webhook']])(
+  'does not offer the AI Code Assistant on a %s project',
+  async (integrationType) => {
+    renderIssueAssign(integrationType);
+
+    await waitFor(() => {
+      expect(getCodefixIntegration).toHaveBeenCalledWith(PROJECT_KEY);
+    });
+    expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+  },
+);
+
+it.each([
+  ['a branch', { branch: 'feature/my-branch' }],
+  ['a pull request', { pullRequest: '1234' }],
+])('offers the AI Code Assistant for an issue on %s of a github project', async (_, overrides) => {
+  renderIssueAssign('github', overrides);
+
+  expect(await screen.findByText(AI_CODE_ASSISTANT)).toBeInTheDocument();
+  // The integration belongs to the project, so the lookup is by project key alone.
+  expect(getCodefixIntegration).toHaveBeenCalledWith(PROJECT_KEY);
+});
+
+it.each([
+  ['a branch', { branch: 'feature/my-branch' }],
+  ['a pull request', { pullRequest: '1234' }],
+])(
+  'does not offer the AI Code Assistant for an issue on %s of a salesforce project',
+  async (_, overrides) => {
+    renderIssueAssign('metadata_api', overrides);
+
+    await waitFor(() => {
+      expect(getCodefixIntegration).toHaveBeenCalledWith(PROJECT_KEY);
+    });
+    expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+  },
+);
+
+it('does not offer the AI Code Assistant when the issue itself is not AI-eligible', async () => {
+  renderIssueAssign('github', { aiCodeFixEnabled: false });
+
+  await waitFor(() => {
+    expect(getCodefixIntegration).toHaveBeenCalledWith(PROJECT_KEY);
+  });
+  expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+});
+
+it('does not look the project up when the AI assistant is switched off', async () => {
+  jest.mocked(isAiAssistantEnabled).mockResolvedValue(false);
+  renderIssueAssign('github');
+
+  await waitFor(() => {
+    expect(isAiAssistantEnabled).toHaveBeenCalled();
+  });
+  expect(screen.queryByText(AI_CODE_ASSISTANT)).not.toBeInTheDocument();
+  expect(getCodefixIntegration).not.toHaveBeenCalled();
+});
+
+function renderIssueAssign(integrationType: string, issueOverrides = {}) {
+  jest.mocked(getCodefixIntegration).mockResolvedValue({
+    integrationType,
+    supported: ['github', 'gitlab'].includes(integrationType),
+  });
+
+  return renderComponent(
+    <CurrentUserContextProvider currentUser={mockLoggedInUser()}>
+      <IssueAssign
+        canAssign
+        isOpen
+        issue={mockIssue(false, {
+          aiCodeFixEnabled: true,
+          organization: 'my-org',
+          project: PROJECT_KEY,
+          ...issueOverrides,
+        })}
+        onAssign={jest.fn()}
+        organization="my-org"
+        togglePopup={jest.fn()}
+      />
+    </CurrentUserContextProvider>,
+  );
+}

--- a/server/sonar-web/src/main/js/components/issue/components/__tests__/IssueCodefixStatusBadge-qa-test.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/__tests__/IssueCodefixStatusBadge-qa-test.tsx
@@ -1,0 +1,179 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { screen, waitFor, within } from '@testing-library/react';
+import { getCodefixIntegration, getCodefixStatus } from '../../../../api/ai-codefix';
+import { getValues } from '../../../../api/settings';
+import { mockIssue } from '../../../../helpers/testMocks';
+import { renderComponent } from '../../../../helpers/testReactTestingUtils';
+import { aiCodefixIntegrationQueryOptions } from '../../../../queries/ai-codefix';
+import AiCodefixBadge from '../IssueCodefixStatusBadge';
+
+jest.mock('../../../../api/ai-codefix');
+jest.mock('../../../../api/settings');
+
+const AI_FIX_AVAILABLE = 'AI Fix Available';
+const GH = 'gh-project';
+const SF = 'sf-project';
+
+const supported = { integrationType: 'github', supported: true };
+const unsupported = { integrationType: 'metadata_api', supported: false };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(getCodefixStatus).mockResolvedValue({ status: '' });
+  jest.mocked(getValues).mockResolvedValue([]);
+});
+
+function mockIntegrations(byProject: Record<string, unknown>) {
+  jest
+    .mocked(getCodefixIntegration)
+    .mockImplementation((projectKey) => Promise.resolve(byProject[projectKey] as any));
+}
+
+/** Marks each badge so a mixed list can be asserted per row. */
+function Row({ issueKey, project }: { issueKey: string; project: string }) {
+  const { data } = useQuery({ ...aiCodefixIntegrationQueryOptions(project), retry: false });
+
+  return (
+    <div data-testid={`row-${issueKey}`}>
+      <AiCodefixBadge issue={mockIssue(false, { key: issueKey, project })} />
+      {/* `data !== undefined` rather than truthiness, so a null payload still counts as resolved. */}
+      <span>{data !== undefined ? `loaded-${issueKey}` : `loading-${issueKey}`}</span>
+    </div>
+  );
+}
+
+describe('QA-A: cross-project contamination in one issue list', () => {
+  it('A1 shows the badge only on the supported row of a mixed list', async () => {
+    mockIntegrations({ [GH]: supported, [SF]: unsupported });
+    renderComponent(
+      <>
+        <Row project={GH} issueKey="gh-issue" />
+        <Row project={SF} issueKey="sf-issue" />
+      </>,
+    );
+
+    await screen.findByText('loaded-gh-issue');
+    await screen.findByText('loaded-sf-issue');
+
+    expect(
+      within(screen.getByTestId('row-gh-issue')).getByText(AI_FIX_AVAILABLE),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('row-sf-issue')).queryByText(AI_FIX_AVAILABLE),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText(AI_FIX_AVAILABLE)).toHaveLength(1);
+  });
+
+  it('A2 keeps rows independent when the unsupported project resolves first', async () => {
+    let resolveGh: (v: unknown) => void = () => {};
+    jest.mocked(getCodefixIntegration).mockImplementation((projectKey) =>
+      projectKey === SF
+        ? Promise.resolve(unsupported as any)
+        : new Promise((resolve) => {
+            resolveGh = resolve;
+          }),
+    );
+    renderComponent(
+      <>
+        <Row project={GH} issueKey="gh-issue" />
+        <Row project={SF} issueKey="sf-issue" />
+      </>,
+    );
+
+    await screen.findByText('loaded-sf-issue');
+    expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+
+    resolveGh(supported);
+    expect(await screen.findByText(AI_FIX_AVAILABLE)).toBeInTheDocument();
+    expect(screen.getAllByText(AI_FIX_AVAILABLE)).toHaveLength(1);
+  });
+
+  it('A3 issues the integration lookup once for many issues of the same project', async () => {
+    mockIntegrations({ [GH]: supported });
+    renderComponent(
+      <>
+        {['i1', 'i2', 'i3', 'i4', 'i5'].map((k) => (
+          <Row key={k} project={GH} issueKey={k} />
+        ))}
+      </>,
+    );
+
+    await screen.findByText('loaded-i5');
+    expect(screen.getAllByText(AI_FIX_AVAILABLE)).toHaveLength(5);
+    expect(jest.mocked(getCodefixIntegration).mock.calls).toHaveLength(1);
+  });
+});
+
+describe('QA-B: unexpected response shapes fail closed without crashing', () => {
+  it.each([
+    ['supported field missing', { integrationType: 'github' }],
+    ['empty object', {}],
+    ['supported as a truthy string', { integrationType: 'github', supported: 'yes' }],
+    ['supported null', { integrationType: 'github', supported: null }],
+    ['null payload', null],
+    ['integration type absent entirely', { supported: false }],
+  ])('B: %s', async (_, payload) => {
+    mockIntegrations({ [GH]: payload });
+    renderComponent(<Row project={GH} issueKey="i1" />);
+
+    await screen.findByText('loaded-i1');
+    expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+  });
+});
+
+describe('QA-C: lookup failures fail closed', () => {
+  it.each([
+    ['403 forbidden', { status: 403 }],
+    ['404 not found', { status: 404 }],
+    ['network error', new Error('Network request failed')],
+  ])('C: %s hides the badge', async (_, rejection) => {
+    jest.mocked(getCodefixIntegration).mockRejectedValue(rejection);
+    renderComponent(<Row project={GH} issueKey="i1" />);
+
+    await waitFor(() => {
+      expect(getCodefixIntegration).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+  });
+});
+
+describe('QA-D: real statuses still surface on an unsupported integration', () => {
+  it.each([
+    ['PENDING', 'AI Fix in Progress'],
+    ['IN_PROGRESS', 'AI Fix in Progress'],
+    ['FIX_GENERATED', 'AI Fix Generated'],
+    ['PULL_REQUEST_CREATED', 'Pull Request Created'],
+    ['FAILED', 'AI Fix Failed'],
+  ])('D: %s renders as "%s" on a Salesforce project', async (status, label) => {
+    mockIntegrations({ [SF]: unsupported });
+    jest.mocked(getCodefixStatus).mockResolvedValue({ status });
+    renderComponent(
+      <AiCodefixBadge
+        issue={mockIssue(false, { key: 'i1', project: SF, codefixStatus: status })}
+      />,
+    );
+
+    expect(await screen.findByText(label)).toBeInTheDocument();
+    expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+  });
+});

--- a/server/sonar-web/src/main/js/components/issue/components/__tests__/IssueCodefixStatusBadge-test.tsx
+++ b/server/sonar-web/src/main/js/components/issue/components/__tests__/IssueCodefixStatusBadge-test.tsx
@@ -1,0 +1,130 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import { getCodefixIntegration, getCodefixStatus } from '../../../../api/ai-codefix';
+import { getValues } from '../../../../api/settings';
+import { mockIssue } from '../../../../helpers/testMocks';
+import { renderComponent } from '../../../../helpers/testReactTestingUtils';
+import { aiCodefixIntegrationQueryOptions } from '../../../../queries/ai-codefix';
+import AiCodefixBadge from '../IssueCodefixStatusBadge';
+
+jest.mock('../../../../api/ai-codefix');
+jest.mock('../../../../api/settings');
+
+const AI_FIX_AVAILABLE = 'AI Fix Available';
+const PROJECT_KEY = 'my-project';
+const INTEGRATION_LOADED = 'integration-loaded';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(getCodefixStatus).mockResolvedValue({ status: '' });
+  jest.mocked(getValues).mockResolvedValue([]);
+});
+
+it.each([['github'], ['gitlab']])(
+  'shows the availability badge for a %s project',
+  async (integrationType) => {
+    renderBadge(integrationType);
+
+    expect(await screen.findByText(AI_FIX_AVAILABLE)).toBeInTheDocument();
+  },
+);
+
+it.each([['metadata_api (Salesforce)'], ['bitbucket'], ['bitbucket-enterprise'], ['webhook']])(
+  'hides the availability badge for a %s project',
+  async (integrationType) => {
+    renderBadge(integrationType);
+
+    // Waiting on the loaded marker — not merely on the request being issued — means this absence cannot be a
+    // not-yet-loaded false negative.
+    expect(await screen.findByText(INTEGRATION_LOADED)).toBeInTheDocument();
+    expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+  },
+);
+
+it('hides the availability badge while the integration is still unknown', () => {
+  renderBadge('github');
+
+  expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+});
+
+it.each([
+  ['a branch', { branch: 'feature/my-branch' }],
+  ['a pull request', { pullRequest: '1234' }],
+])('shows the availability badge for an issue on %s of a github project', async (_, overrides) => {
+  renderBadge('github', overrides);
+
+  expect(await screen.findByText(AI_FIX_AVAILABLE)).toBeInTheDocument();
+  // The integration belongs to the project, not the branch, so the lookup is by project key alone.
+  expect(getCodefixIntegration).toHaveBeenCalledWith(PROJECT_KEY);
+});
+
+it.each([
+  ['a branch', { branch: 'feature/my-branch' }],
+  ['a pull request', { pullRequest: '1234' }],
+])(
+  'hides the availability badge for an issue on %s of a salesforce project',
+  async (_, overrides) => {
+    renderBadge('metadata_api', overrides);
+
+    expect(await screen.findByText(INTEGRATION_LOADED)).toBeInTheDocument();
+    expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+  },
+);
+
+it('still reports a real codefix status on an unsupported integration', async () => {
+  jest.mocked(getCodefixStatus).mockResolvedValue({ status: 'PULL_REQUEST_CREATED' });
+  renderBadge('metadata_api', { codefixStatus: 'PULL_REQUEST_CREATED' });
+
+  expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
+  expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+});
+
+it('does not advertise availability for an unrecognised status on an unsupported integration', async () => {
+  // getAiCodefixStatusDisplay falls through to "available" for any status it does not know.
+  jest.mocked(getCodefixStatus).mockResolvedValue({ status: 'SOME_NEW_STATUS' });
+  renderBadge('metadata_api', { codefixStatus: 'SOME_NEW_STATUS' });
+
+  expect(await screen.findByText(INTEGRATION_LOADED)).toBeInTheDocument();
+  expect(screen.queryByText(AI_FIX_AVAILABLE)).not.toBeInTheDocument();
+});
+
+function renderBadge(integrationType: string, issueOverrides = {}) {
+  jest.mocked(getCodefixIntegration).mockResolvedValue({
+    integrationType,
+    supported: ['github', 'gitlab'].includes(integrationType),
+  });
+
+  return renderComponent(
+    <>
+      <AiCodefixBadge issue={mockIssue(false, { project: PROJECT_KEY, ...issueOverrides })} />
+      <ProjectTagsLoaded />
+    </>,
+  );
+}
+
+/** Renders a marker once the badge's integration lookup has resolved, giving the tests a real load barrier. */
+function ProjectTagsLoaded() {
+  const { data } = useQuery(aiCodefixIntegrationQueryOptions(PROJECT_KEY));
+
+  return <span>{data ? INTEGRATION_LOADED : 'integration-loading'}</span>;
+}

--- a/server/sonar-web/src/main/js/queries/ai-codefix.ts
+++ b/server/sonar-web/src/main/js/queries/ai-codefix.ts
@@ -1,0 +1,53 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { queryOptions, useQueries, useQuery } from '@tanstack/react-query';
+import { uniq } from 'lodash';
+import { getCodefixIntegration } from '../api/ai-codefix';
+import { StaleTime } from './common';
+
+export function aiCodefixIntegrationQueryOptions(projectKey: string) {
+  return queryOptions({
+    queryKey: ['codefix', 'integration', projectKey],
+    queryFn: () => getCodefixIntegration(projectKey),
+    staleTime: StaleTime.LONG,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useIsAiCodefixSupportedIntegration(projectKey?: string): boolean {
+  const {data} = useQuery({
+    ...aiCodefixIntegrationQueryOptions(projectKey ?? ''),
+    enabled: Boolean(projectKey),
+  });
+
+  return data?.supported === true;
+}
+
+export function useAreAllAiCodefixSupportedIntegrations(projectKeys: string[]): boolean {
+  const keys = uniq(projectKeys);
+  const results = useQueries({
+    queries: keys.filter(Boolean).map((key) => aiCodefixIntegrationQueryOptions(key)),
+  });
+
+  const everyProjectIdentified = keys.length > 0 && keys.every(Boolean);
+
+  return everyProjectIdentified && results.every(({ data }) => data?.supported === true);
+}


### PR DESCRIPTION
This pull request disables AI code fixes for unsupported ALM integrations and introduces a new data transfer object to manage integration types. Additionally, it updates the code fix service and related tests to accommodate these changes.

Disabled AI code fixes for unsupported ALM integrations in the CodefixService.

Introduced CodefixIntegrationDto to encapsulate integration type and support status.

Updated getIntegration method in CodefixService to return integration support information.

Modified error handling to restrict AI code fixes to GitHub and GitLab integrations only.

Enhanced unit tests to reflect changes in integration type handling and support checks.

